### PR TITLE
Pull request for carmen

### DIFF
--- a/lib/carmen.rb
+++ b/lib/carmen.rb
@@ -99,6 +99,10 @@ module Carmen
     collection.each do |m|
       return m[index_to_retrieve] if m[index_to_match].downcase == value.downcase
     end
+    # In case we didn't get any results we'll try a broader search (via Regexp)
+    collection.each do |m|
+      return m[index_to_retrieve] if m[index_to_match].downcase.match(value.downcase)
+    end
     nil
   end
   

--- a/test/carmen_test.rb
+++ b/test/carmen_test.rb
@@ -11,6 +11,7 @@ class TestCarmen < Test::Unit::TestCase
   def test_country_code
     assert_equal 'CA', Carmen.country_code('Canada')
     assert_equal 'CA', Carmen.country_code('canada')
+    assert_equal 'IR', Carmen.country_code('Iran')
   end
   
   def test_country_codes


### PR DESCRIPTION
Hi Jim,

I've made some changes to your carmen gem in order to make working with other country lists easier. For example in carmen, when looking up the ISO code for Iran you have to use the full name - Iran, Islamic Republic of. Now you can just search for 'Iran'. 
I also changed the search to be case-insensitive and corrected two failing tests.

Kind regards,
Wojtek
