### PR TITLE
Untitled

### DIFF
--- a/data/countries/de.yml
+++ b/data/countries/de.yml
@@ -169,7 +169,7 @@
   - FX
 - - Gabun
   - GA
-- - "Vereinigtes Königreich Großritannien und Nordirland"
+- - "Vereinigtes Königreich Großbritannien und Nordirland"
   - GB
 - - Grenada
   - GD


### PR DESCRIPTION
'NO' Norway quote bug in de.yml
About a year ago you fixed the en.yml file to quote 'NO' to avoid this being treated as false.
Same fix applied to de.yml

Great Britain misspelled in de.yml (kinda like my commit comment.  oops)
