### PR TITLE
Gem install in broken on 0.2.6

### DIFF
--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -61,7 +61,6 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<carmen>, [">= 0"])
       s.add_development_dependency(%q<mocha>, [">= 0"])
       s.add_development_dependency(%q<rails>, [">= 0"])
       s.add_development_dependency(%q<hanna>, [">= 0"])
@@ -69,7 +68,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rails>, [">= 0"])
       s.add_development_dependency(%q<hanna>, [">= 0"])
     else
-      s.add_dependency(%q<carmen>, [">= 0"])
       s.add_dependency(%q<mocha>, [">= 0"])
       s.add_dependency(%q<rails>, [">= 0"])
       s.add_dependency(%q<hanna>, [">= 0"])
@@ -78,7 +76,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hanna>, [">= 0"])
     end
   else
-    s.add_dependency(%q<carmen>, [">= 0"])
     s.add_dependency(%q<mocha>, [">= 0"])
     s.add_dependency(%q<rails>, [">= 0"])
     s.add_dependency(%q<hanna>, [">= 0"])


### PR DESCRIPTION
This is the output I get when I try to install 0.2.6: https://gist.github.com/866261

The gem shouldn't have a dependency on itself.
