### PR TITLE
Adding missing state - Gujarat (India)

### DIFF
--- a/data/states/in.yml
+++ b/data/states/in.yml
@@ -12,6 +12,8 @@
   - CT
 - - Goa
   - GA
+- - Gujarat
+  - GJ
 - - Haryana
   - HR
 - - Himachal Pradesh


### PR DESCRIPTION
Hi Jim,

The state of Gujarat in India is missing in carmen :)

Thanks!
Swaroop
