### PR TITLE
Allow user to prepend countries to the countries list in order to allow for countries likely to be picked

### DIFF
--- a/lib/carmen.rb
+++ b/lib/carmen.rb
@@ -16,13 +16,15 @@ end
 
 module Carmen
   class << self
-    attr_accessor :default_country, :default_locale, :excluded_countries, :excluded_states
+    attr_accessor :default_country, :default_locale, :excluded_countries, :excluded_states,
+                  :prepended_countries
   end
 
   self.default_country = 'US'
   self.default_locale = :en
   self.excluded_countries = []
   self.excluded_states = {}
+  self.prepended_countries = []
 
   @data_path = File.join(File.dirname(__FILE__), '..', 'data')
 
@@ -57,8 +59,9 @@ module Carmen
       @countries[locale] = YAML.load_file(localized_data)
     end
 
-    # Return data after filtering excluded countries
-    @countries[locale].reject { |c| excluded_countries.include?( c[1] ) }
+    # Return data after filtering excluded countries and prepending prepended countries
+    result = @countries[locale].reject { |c| excluded_countries.include?( c[1] ) }
+    prepended_countries.map { |code| [ search_collection(result, code, 1, 0), code ] } + result
   end
 
 

--- a/test/carmen_test.rb
+++ b/test/carmen_test.rb
@@ -123,6 +123,19 @@ class TestCarmen < Test::Unit::TestCase
       Carmen.excluded_states = {}
   end
 
+  def test_prepended_countries
+    us_original_index = Carmen.countries.index(['United States', 'US'])
+    Carmen.prepended_countries = %w(US CA AU)
+    countries = Carmen.countries
+    assert_equal 0, countries.index(['United States', 'US'])
+    assert_equal 1, countries.index(['Canada', 'CA'])
+    assert_equal 2, countries.index(['Australia', 'AU'])
+
+    assert_equal 3 + us_original_index, countries.rindex(['United States', 'US'])
+
+    Carmen.prepended_countries = []
+  end
+
   def test_invalid_country_exception
     assert_raises Carmen::NonexistentCountry do
       Carmen::state_codes('ZZ')


### PR DESCRIPTION
E.g. in an American site:
Carmen.prepended_countries = %w(US CA)

US and Canada show up at the top, and further down in the list.
