### PR TITLE
Bug caused by extra '' in country data file

### DIFF
--- a/data/countries/en.yml
+++ b/data/countries/en.yml
@@ -330,7 +330,7 @@
 - - Northern Mariana Islands
   - MP
 - - Norway
-  - 'NO'
+  - NO
 - - Oman
   - OM
 - - Pakistan


### PR DESCRIPTION
Hi, Jim... thanks for Carmen.  Use it often.  

I've removed extra '' around NO.  Was crashing when calling Carmen::state_name('NO','NO').  Not a mind-blowing contribution but it did cause me a bit of a headache. :)
