### PR TITLE
Country updates

### DIFF
--- a/data/countries/en.yml
+++ b/data/countries/en.yml
@@ -25,6 +25,8 @@
   - AM
 - - Aruba
   - AW
+- - Ascension Island
+  - AC
 - - Australia
   - AU
 - - Austria
@@ -53,6 +55,8 @@
   - BT
 - - Bolivia
   - BO
+- - Bonaire, Sint Eustatius and Saba
+  - BQ
 - - Bosnia and Herzegovina
   - BA
 - - Botswana
@@ -105,12 +109,14 @@
   - CK
 - - Costa Rica
   - CR
-- - Côte d'Ivoîre
+- - Côte d'Ivoire
   - CI
 - - Croatia
   - HR
 - - Cuba
   - CU
+- - Curaçao
+  - CW
 - - Cyprus
   - CY
 - - Czech Republic
@@ -259,7 +265,7 @@
   - LU
 - - Macao
   - MO
-- - Macedonia, the Former Yugoslav Republic of
+- - Macedonia, Republic of
   - MK
 - - Madagascar
   - MG
@@ -399,6 +405,8 @@
   - SL
 - - Singapore
   - SG
+- - Sint Maarten (Dutch part)
+  - SX
 - - Slovakia
   - SK
 - - Slovenia
@@ -447,6 +455,8 @@
   - TO
 - - Trinidad and Tobago
   - TT
+- - Tristan da Cunha
+  - TA
 - - Tunisia
   - TN
 - - Turkey


### PR DESCRIPTION
- Split Saint Helena, Ascension Island and Tristan da Cunha into 3 separate entries; they acquired independent equal status in 2010.
- Added Bonaire, Sint Eustatius and Saba
- Fix spelling of Cote d'Ivoire again -- no circumflex accent on the i, only on the o, in UTF-8 (github's in-line edit doesn't handle UTF-8 properly)
- Added Curaçao
- Adjust spelling of Macedonia (dropping the former Yugoslav part), departing from UN standard, but in accordance with country's own name
- Added Sint Maarten (Dutch part)

Sources: 
- http://www.itu.int/dms_pub/itu-t/opb/sp/T-SP-E.164D-2011-MSW-E.doc
- http://en.wikipedia.org/wiki/List_of_country_calling_codes
- http://en.wikipedia.org/wiki/ISO_3166-1
