### PR TITLE
rename Libyan Arab Jamahiriya to Libya (in English)

### DIFF
--- a/data/countries/en.yml
+++ b/data/countries/en.yml
@@ -255,7 +255,7 @@
   - LS
 - - Liberia
   - LR
-- - Libyan Arab Jamahiriya
+- - Libya
   - LY
 - - Liechtenstein
   - LI


### PR DESCRIPTION
We've had users complain about using "libyan arab jamahiriya", which is the name the Gaddafi gov uses for the country, as the name for Libya.  We changed it in our branch and though you might want to as well.

It appears that several of the language files already use "Libya" as the country name, with the exception of the German file.
