### PR TITLE
adding South Sudan

### DIFF
--- a/data/countries/en.yml
+++ b/data/countries/en.yml
@@ -419,6 +419,8 @@
   - ZA
 - - South Georgia and the South Sandwich Islands
   - GS
+- - South Sudan, Republic of
+  - SS
 - - Spain
   - ES
 - - Sri Lanka


### PR DESCRIPTION
South Sudan is now an independent nation: http://en.wikipedia.org/wiki/South_Sudan

We’ve added an entry to the English data file, but none of the others. 
