### PR TITLE
fall back to default locale if selected locale is missing

### DIFF
--- a/lib/carmen.rb
+++ b/lib/carmen.rb
@@ -52,7 +52,8 @@ module Carmen
       # Check if data in the specified locale is available
       localized_data = File.join(@data_path, "countries", "#{locale}.yml")
       unless File.exists?(localized_data)
-        raise(UnavailableLocale, "Could not load countries for '#{locale}' locale")
+        localized_data = File.join(@data_path, "countries", "#{@default_locale}.yml")
+        # raise(UnavailableLocale, "Could not load countries for '#{locale}' locale")
       end
 
       # As the data exists, load it


### PR DESCRIPTION
In production users might choose a locale that is supported by the website but not yet supported by carmen.
