### PR TITLE
HTML safe country options for select

### DIFF
--- a/lib/carmen/action_view_helpers.rb
+++ b/lib/carmen/action_view_helpers.rb
@@ -34,7 +34,7 @@ module ActionView
           end
         end
 
-        return country_options + options_for_select(Carmen.countries, priority_country_codes.include?(selected) ? nil : selected)
+        (country_options + options_for_select(Carmen.countries, priority_country_codes.include?(selected) ? nil : selected)).html_safe
       end
     end
 


### PR DESCRIPTION
Just started using Carmen in my rails 3.2.2 project and the country selects weren't working properly. Just added html_safe onto the results of country_options_for_select and they work.
