### PR TITLE
fixed a problem with the gemspec throwing an error

### DIFF
--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# -*- encoding: utf-8 -*-
+
 require File.expand_path('../lib/carmen/version', __FILE__)
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
got the following error on ubuntu 10.04.4 LTS using rubygems 1.3.7:

WARNING:  #<ArgumentError: Illformed requirement ["#<Syck::DefaultKey:0x00000009c9fc80> 2.6.1"]>
# -*- encoding: utf-8 -*-

Gem::Specification.new do |s|
  s.name = %q{carmen}
  s.version = "1.0.0.beta2"
...

it seems that the encoding comment in the gemspec was causing the problem -- i made this small change and everything worked...
