### PR TITLE
Added nationality attribute to countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,9 @@ set of locale paths used by the backend:
 
 If you are using your own backend, then follow the steps necessary to have it
 load your additional files instead.
+
+## TODO
+
+Fill the missing pieces from the different locales (`common_name`, `name`, `nationality`)
+
+Create the fallback chain for nationality

--- a/lib/carmen/country.rb
+++ b/lib/carmen/country.rb
@@ -25,6 +25,10 @@ module Carmen
     def official_name
       Carmen.i18n_backend.translate(path('official_name'))
     end
+    
+    def nationality
+      Carmen.i18n_backend.translate(path('nationality'))
+    end
 
     def self.all
       World.instance.subregions

--- a/locale/cn/world.yml
+++ b/locale/cn/world.yml
@@ -5,959 +5,1199 @@ cn:
       common_name: !!null 
       name: 安道尔共和国
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: 阿拉伯联合酋长国
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: 阿富汗
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: 安提瓜和巴布达
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: 安圭拉岛
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: 阿尔巴尼亚
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: 亚美尼亚
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: 荷属安德烈斯群岛
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: 安哥拉
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: 南极洲
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: 阿根廷
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: 美属萨摩亚
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: 奥地利
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: 澳大利亚
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: 阿鲁巴岛
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: 奥兰群岛
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: 阿塞拜疆
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: 波黑
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: 巴巴多斯岛
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: 孟加拉国
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: 比利时
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: 布基纳法索
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: 保加利亚
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: 巴林
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: 布隆迪
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: 贝宁
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: 圣巴泰勒米
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: 百慕大群岛
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: 文莱
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: 玻利维亚
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: 巴西
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: 巴哈马群岛
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: 不丹
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: 布维岛
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: 博茨瓦纳
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: 白俄罗斯
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: 伯利兹城
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: 加拿大
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: 科科斯(基林)群岛
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: 中非共和国
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: 刚果
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: 瑞士
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: 科特迪瓦
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: 库克群岛
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: 智利
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: 喀麦隆
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: 中国
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: 哥伦比亚
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: 哥斯达黎加
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: 古巴
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: 佛得角
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: 圣诞岛
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: 塞浦路斯
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: 捷克共和国
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: 德国
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: 吉布提
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: 丹麦
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: 多米尼加
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: 多米尼加共和国
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: 阿尔及利亚
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: 厄瓜多尔
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: 爱沙尼亚
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: 埃及
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: 西撒哈拉
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: 厄立特里亚
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: 西班牙
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: 埃塞俄比亚
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: 芬兰
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: 斐济
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: 福克兰群岛
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: 密克罗尼西亚联邦
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: 法罗群岛
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: 法国
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: 加蓬
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: 英国
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: 格林纳达
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: 格鲁吉亚
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: 法属圭亚那
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: 格恩西
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: 加纳
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: 直布罗陀
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: 格陵兰
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: 冈比亚
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: 几内亚
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: 瓜德罗普
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: 赤道几内亚
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: 希腊
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: 南乔治亚岛和南桑威奇群岛
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: 危地马拉
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: 关岛
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: 几内亚比绍
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: 圭亚那
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: 香港
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: 赫德岛和麦克唐纳群岛
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: 洪都拉斯
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: 克罗地亚
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: 海底
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: 匈牙利
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: 印度尼西亚
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: 爱尔兰
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: 以色列
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: 马恩岛
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: 印度
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: 伊拉克
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: 冰岛
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: 意大利
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: 泽西
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: 牙买加
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: 约旦
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: 日本
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: 肯尼亚
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: 吉尔吉斯斯坦
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: 柬埔寨
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: 基里巴斯
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: 科摩罗
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: 圣基茨和尼维斯
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: 韩国
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: 科索沃
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: 科威特
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: 开曼群岛
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: 哈萨克斯坦
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: 老挝人民民主共和国
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: 黎巴嫩
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: 圣卢西亚
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: 列支敦士登
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: 斯里兰卡
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: 利比里亚
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: 莱索托
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: 立陶宛
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: 卢森堡
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: 拉脱维亚
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: 阿拉伯利比亚共和国
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: 摩洛哥
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: 摩纳哥
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: 摩尔多瓦共和国
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: 蒙特内哥罗
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: 圣马丁
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: 马达加斯加
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: 马绍尔群岛
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: 马其顿
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: 马里
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: 缅甸
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: 澳门
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: 北马利亚纳群岛
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: 马提尼克
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: 毛里塔尼亚
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: 蒙特塞拉特
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: 马耳他
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: 毛里求斯
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: 马尔代夫
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: 马拉维
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: 墨西哥
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: 马来西亚
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: 莫桑比克
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: 纳米比亚
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: 新喀里多尼亚
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: 尼日尔
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: 诺福克到
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: 尼日利亚
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: 尼加拉瓜
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: 荷兰
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: 挪威
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: 尼泊尔
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: 瑙鲁
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: 纽埃
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: 新西兰
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: 阿曼
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: 巴拿马
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: 秘鲁
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: 法属波利尼西亚
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: 巴布亚新几内亚
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: 菲律宾
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: 巴基斯坦
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: 波兰
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: 圣皮埃尔和密克隆
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: 皮特凯恩
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: 波多黎各
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: 葡萄牙
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: 帕劳
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: 巴拉圭
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: 卡塔尔
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: 留尼旺
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: 罗马尼亚
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: 塞尔维亚
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: 俄罗斯联邦
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: 卢旺达
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: 沙特阿拉伯
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: 所罗门群岛
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: 塞舌尔
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: 苏丹
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: 瑞典
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: 新加坡
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: 圣赫勒拿
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: 斯洛文尼亚
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: 斯瓦尔巴岛和扬马延岛
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: 斯诺伐克
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: 塞拉利昂
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: 圣马力诺
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: 塞内加尔
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: 索马里
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: 苏里南
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: 圣多美和普林西比
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: 萨尔瓦多
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: 阿拉伯叙利亚共和国
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: 斯威士兰
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: 特克斯和凯克斯群岛
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: 乍得
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: 法国南部领土
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: 多哥
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: 泰国
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: 塔吉克斯坦
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: 托克劳
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: 东帝汶
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: 土库曼斯坦
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: 突尼斯
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: 汤加
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: 土耳其
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: 特里尼达和多巴哥
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: 图瓦卢
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: 台湾
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: 坦桑尼亚共和国
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: 乌克兰
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: 乌干达
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: 美国本土外小岛屿
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: 美国
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: 乌拉圭
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: 乌兹别克斯坦
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: 罗马教廷
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: 圣文森特和格林纳丁斯
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: 委内瑞拉
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: 英属维京群岛
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: 美属维尔京群岛
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: 越南
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: 瓦努阿图
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: 萨摩亚
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: 也门
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: 马约特
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: 南非
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: 赞比亚
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: 津巴布韦
       official_name: !!null 
+      nationality: !!null 

--- a/locale/cs/world.yml
+++ b/locale/cs/world.yml
@@ -5,979 +5,1224 @@ cs:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Spojené arabské emiráty
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afghánistán
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua a Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albánie
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Arménie
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Nizozemské Antily
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktida
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Americká Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Rakousko
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Austrálie
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Alandské ostrovy
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Ázerbájdžán
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosna a Hercegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladéš
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgie
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulharsko
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrajn
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint Barthelemy
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermudy
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunej Darussalam
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolívie
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brazílie
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamy
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhútán
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouvet Island
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Bělorusko
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Kokosové ostrovy (Keeling) ostrovy
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongo, demokratická republika
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Středoafrická republika
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Kongo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Švýcarsko
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Pobřeží slonoviny
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cookovy ostrovy
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolumbie
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Kuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Cape Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Vánoční ostrov
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Kypr
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Česká republika
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Německo
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Džibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dánsko
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominikánská republika
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Alžírsko
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonsko
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egypt
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Západní Sahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Španělsko
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiopie
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finsko
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fidži
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandské ostrovy (Malvíny)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronésie, Federativní státy
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Francie
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Velká Británie
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Gruzie
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Francouzská Guyana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grónsko
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambie
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Rovníková Guinea
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Řecko
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Jižní Georgie a Jižní Sandwichovy ostrovy
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heardův ostrov a McDonaldovy ostrovy
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Chorvatsko
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Maďarsko
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonésie
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irsko
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Izrael
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isle of Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Indie
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Britské indickooceánské území
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irák
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Íránská islámská republika
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Island
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Itálie
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamajka
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordánsko
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japonsko
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Keňa
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kyrgyzstán
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kambodža
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komory
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Čína
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Korea, lidově demokratická republika v
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Korejská republika
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Kosovo
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuvajt
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Kajmanské ostrovy
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazachstán
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laoské lidově demokratické republiky
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Lichtenštejnsko
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Srí Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Libérie
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litva
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Lucembursko
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Lotyšsko
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Lybie
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Maroko
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldavská republika
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Černá Hora
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Saint Martin (francouzská část)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshallovy ostrovy
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Makedonie, Bývalá jugoslávská republika
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolsko
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Severní Mariany
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinik
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritánie
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maledivy
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Mexiko
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malajsie
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mosambik
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibie
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nová Kaledonie
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigérie
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nikaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Nizozemsko
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norsko
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepál
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nový Zéland
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Omán
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Francouzská Polynésie
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua Nová Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipíny
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pákistán
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polsko
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint Pierre a Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestinská území, okupovaná
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugalsko
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     pro:
       common_name: !!null 
       name: Faerské ostrovy
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Katar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Rumunsko
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Srbsko
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Ruská federace
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Rwanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saúdská Arábie
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Šalamounovy ostrovy
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychely
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Súdán
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Švédsko
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Svatá Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovinsko
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Špicberky a Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovensko
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somálsko
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Surinam
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Svatý Tomáš a Princův
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syrská arabská republika
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Svazijsko
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Ostrovy Turks a Caicos
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Francouzská jižní území
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thajsko
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tádžikistán
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Východní Timor
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistán
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunisko
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turecko
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad a Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Tchaj-wan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzánie, Sjednocená republika
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukrajina
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Spojené státy Menší odlehlé ostrovy
       official_name: !!null 
+      nationality: !!null 
     usa:
       common_name: !!null 
       name: Spojené státy americké
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistán
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Svatý stolec (Vatikánský městský stát)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Svatý Vincent a Grenadiny
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Britské Panenské ostrovy
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Americké Panenské ostrovy
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Viet Nam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis a Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Jihoafrická republika
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambie
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: !!null 
     Čr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 

--- a/locale/de/world.yml
+++ b/locale/de/world.yml
@@ -5,1047 +5,1309 @@ de:
       common_name: !!null 
       name: Ascension (verwaltet von St. Helena)
       official_name: !!null 
+      nationality: !!null 
     ad:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Vereinigte Arabische Emirate
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afghanistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua und Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albanien
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenien
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Niederländische Antillen
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktis
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentinien
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Amerikanisch-Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Österreich
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australien
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Åland
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Aserbaidschan
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnien und Herzegowina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesch
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgien
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgarien
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrain
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint-Barthélemy
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei Darussalam
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivien
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brasilien
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamas
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: !!null 
     bu:
       common_name: !!null 
       name: Burma (jetzt Myanmar)
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouvetinsel
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Belarus (Weißrussland)
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Kokosinseln
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongo, Demokratische Republik (ehem. Zaire)
       official_name: !!null 
+      nationality: !!null 
     ce:
       common_name: !!null 
       name: Europäische Gemeinschaft
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Zentralafrikanische Republik
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Republik Kongo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Schweiz (Confoederatio Helvetica)
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Côte d'Ivoire (Elfenbeinküste)
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cookinseln
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: China, Volksrepublik
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolumbien
       official_name: !!null 
+      nationality: !!null 
     cp:
       common_name: !!null 
       name: Clipperton
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cs:
       common_name: !!null 
       name: Tschechoslowakei (ehemalig)
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Kuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Kap Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Weihnachtsinsel
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Zypern
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Tschechische Republik
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Deutschland
       official_name: !!null 
+      nationality: !!null 
     dg:
       common_name: !!null 
       name: Diego Garcia
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Dschibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dänemark
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominikanische Republik
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algerien
       official_name: !!null 
+      nationality: !!null 
     ea:
       common_name: !!null 
       name: Ceuta, Melilla
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estland
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Ägypten
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Westsahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Spanien
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Äthiopien
       official_name: !!null 
+      nationality: !!null 
     eu:
       common_name: !!null 
       name: Europäische Union
       official_name: !!null 
+      nationality: !!null 
     fi (sf):
       common_name: !!null 
       name: Finnland
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fidschi
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandinseln
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronesien
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Färöer
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Frankreich
       official_name: !!null 
+      nationality: !!null 
     fx:
       common_name: !!null 
       name: Frankreich (ohne Übersee-Départements)
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabun
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Vereinigtes Königreich Großbritannien und Nordirland
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgien
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Französisch-Guayana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey (Kanalinsel)
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grönland
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Äquatorialguinea
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Griechenland
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Südgeorgien und die Südlichen Sandwichinseln
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hongkong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heard und McDonaldinseln
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Kroatien
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Ungarn
       official_name: !!null 
+      nationality: !!null 
     ic:
       common_name: !!null 
       name: Kanarische Inseln
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesien
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irland
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israel
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Insel Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Indien
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Britisches Territorium im Indischen Ozean
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran, Islamische Republik
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Island
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italien
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey (Kanalinsel)
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaika
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordanien
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japan
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenia
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirgisistan
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kambodscha
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komoren
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: St. Kitts und Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Korea, Demokratische Volksrepublik (Nordkorea)
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Korea, Republik (Südkorea)
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Kosovo
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Kaimaninseln
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kasachstan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos, Demokratische Volksrepublik
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: St. Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litauen
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxemburg
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Lettland
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libysch-Arabische Dschamahirija (Libyen)
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marokko
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldawien (Republik Moldau)
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Saint-Martin (franz. Teil)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshallinseln
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Mazedonien, ehem. jugoslawische Republik
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar (Burma)
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolei
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Nördliche Marianen
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinique
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauretanien
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Malediven
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Mexiko
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malaysia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mosambik
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibia
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Neukaledonien
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolkinsel
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Niederlande
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norwegen
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nt:
       common_name: !!null 
       name: Neutrale Zone (Saudi-Arabien und Irak bis 1993)
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Neuseeland
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Französisch-Polynesien
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua-Neuguinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Philippinen
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polen
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint-Pierre und Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairninseln
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palästinensische Autonomiegebiete
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Katar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Réunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Rumänien
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Serbien
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Russische Föderation
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saudi-Arabien
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Salomonen
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychellen
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Schweden
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: St. Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slowenien
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard und Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slowakei
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: São Tomé und Príncipe
       official_name: !!null 
+      nationality: !!null 
     su:
       common_name: !!null 
       name: ! 'UdSSR (jetzt: Russische Föderation)'
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syrien, Arabische Republik
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Swasiland
       official_name: !!null 
+      nationality: !!null 
     ta:
       common_name: !!null 
       name: Tristan da Cunha (verwaltet von St. Helena)
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks- und Caicosinseln
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Tschad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Französische Süd- und Antarktisgebiete
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thailand
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tadschikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Osttimor (Timor-Leste)
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunesien
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Türkei
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad und Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Republik China (Taiwan)
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tansania, Vereinigte Republik
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukraine
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: United States Minor Outlying Islands
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Vereinigte Staaten von Amerika
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Usbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Vatikanstadt
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: St. Vincent und die Grenadinen
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Britische Jungferninseln
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Amerikanische Jungferninseln
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis und Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     yu:
       common_name: !!null 
       name: Jugoslawien (ehemalig)
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Südafrika
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Sambia
       official_name: !!null 
+      nationality: !!null 
     zr:
       common_name: !!null 
       name: Zaire (jetzt Demokratische Republik Kongo)
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Simbabwe
       official_name: !!null 
+      nationality: !!null 

--- a/locale/en/world.yml
+++ b/locale/en/world.yml
@@ -5,995 +5,1244 @@ en:
       common_name: !!null 
       name: Andorra
       official_name: Principality of Andorra
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: United Arab Emirates
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afghanistan
       official_name: Islamic Republic of Afghanistan
+      nationality: Afghan
     ag:
       common_name: !!null 
       name: Antigua and Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albania
       official_name: Republic of Albania
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenia
       official_name: Republic of Armenia
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: Republic of Angola
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarctica
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: Argentine Republic
+      nationality: !!null 
     as:
       common_name: !!null 
       name: American Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Austria
       official_name: Republic of Austria
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australia
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Åland Islands
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaijan
       official_name: Republic of Azerbaijan
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnia and Herzegovina
       official_name: Republic of Bosnia and Herzegovina
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: People's Republic of Bangladesh
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgium
       official_name: Kingdom of Belgium
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgaria
       official_name: Republic of Bulgaria
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrain
       official_name: Kingdom of Bahrain
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: Republic of Burundi
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: Republic of Benin
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint Barthélemy
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei Darussalam
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: Bolivia
       name: Bolivia, Plurinational State of
       official_name: Plurinational State of Bolivia
+      nationality: !!null 
     bq:
       common_name: !!null 
       name: Bonaire, Sint Eustatius and Saba
       official_name: Bonaire, Sint Eustatius and Saba
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brazil
       official_name: Federative Republic of Brazil
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamas
       official_name: Commonwealth of the Bahamas
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: Kingdom of Bhutan
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouvet Island
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: Republic of Botswana
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Belarus
       official_name: Republic of Belarus
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Canada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Cocos (Keeling) Islands
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Congo, The Democratic Republic of the
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Central African Republic
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Congo
       official_name: Republic of the Congo
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Switzerland
       official_name: Swiss Confederation
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Côte d'Ivoire
       official_name: Republic of Côte d'Ivoire
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cook Islands
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: Republic of Chile
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Cameroon
       official_name: Republic of Cameroon
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: China
       official_name: People's Republic of China
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Colombia
       official_name: Republic of Colombia
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: Republic of Costa Rica
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Cuba
       official_name: Republic of Cuba
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Cape Verde
       official_name: Republic of Cape Verde
+      nationality: !!null 
     cw:
       common_name: !!null 
       name: Curaçao
       official_name: Curaçao
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Christmas Island
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Cyprus
       official_name: Republic of Cyprus
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Czech Republic
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Germany
       official_name: Federal Republic of Germany
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Djibouti
       official_name: Republic of Djibouti
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Denmark
       official_name: Kingdom of Denmark
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: Commonwealth of Dominica
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominican Republic
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algeria
       official_name: People's Democratic Republic of Algeria
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: Republic of Ecuador
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonia
       official_name: Republic of Estonia
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egypt
       official_name: Arab Republic of Egypt
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Western Sahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Spain
       official_name: Kingdom of Spain
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Ethiopia
       official_name: Federal Democratic Republic of Ethiopia
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finland
       official_name: Republic of Finland
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fiji
       official_name: Republic of Fiji
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falkland Islands (Malvinas)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Micronesia, Federated States of
       official_name: Federated States of Micronesia
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Faroe Islands
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: France
       official_name: French Republic
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: Gabonese Republic
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: United Kingdom
       official_name: United Kingdom of Great Britain and Northern Ireland
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgia
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: French Guiana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: Republic of Ghana
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Greenland
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: Republic of the Gambia
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: Republic of Guinea
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Equatorial Guinea
       official_name: Republic of Equatorial Guinea
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Greece
       official_name: Hellenic Republic
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: South Georgia and the South Sandwich Islands
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: Republic of Guatemala
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: Republic of Guinea-Bissau
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: Republic of Guyana
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: Hong Kong Special Administrative Region of China
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heard Island and McDonald Islands
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: Republic of Honduras
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Croatia
       official_name: Republic of Croatia
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: Republic of Haiti
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Hungary
       official_name: Hungary
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesia
       official_name: Republic of Indonesia
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Ireland
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israel
       official_name: State of Israel
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isle of Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: India
       official_name: Republic of India
+      nationality: !!null 
     io:
       common_name: !!null 
       name: British Indian Ocean Territory
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Iraq
       official_name: Republic of Iraq
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran, Islamic Republic of
       official_name: Islamic Republic of Iran
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Iceland
       official_name: Republic of Iceland
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italy
       official_name: Italian Republic
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaica
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordan
       official_name: Hashemite Kingdom of Jordan
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japan
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenya
       official_name: Republic of Kenya
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kyrgyzstan
       official_name: Kyrgyz Republic
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Cambodia
       official_name: Kingdom of Cambodia
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: Republic of Kiribati
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Comoros
       official_name: Union of the Comoros
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Saint Kitts and Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Korea, Democratic People's Republic of
       official_name: Democratic People's Republic of Korea
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Korea, Republic of
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: State of Kuwait
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Cayman Islands
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazakhstan
       official_name: Republic of Kazakhstan
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Lao People's Democratic Republic
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Lebanon
       official_name: Lebanese Republic
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: Principality of Liechtenstein
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: Democratic Socialist Republic of Sri Lanka
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: Republic of Liberia
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: Kingdom of Lesotho
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Lithuania
       official_name: Republic of Lithuania
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxembourg
       official_name: Grand Duchy of Luxembourg
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Latvia
       official_name: Republic of Latvia
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libya
       official_name: Libya
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Morocco
       official_name: Kingdom of Morocco
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: Principality of Monaco
+      nationality: !!null 
     md:
       common_name: Moldova
       name: Moldova, Republic of
       official_name: Republic of Moldova
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: Montenegro
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Saint Martin (French part)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagascar
       official_name: Republic of Madagascar
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshall Islands
       official_name: Republic of the Marshall Islands
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedonia, Republic of
       official_name: The Former Yugoslav Republic of Macedonia
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: Republic of Mali
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: Republic of Myanmar
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolia
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: Macao Special Administrative Region of China
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Northern Mariana Islands
       official_name: Commonwealth of the Northern Mariana Islands
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinique
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritania
       official_name: Islamic Republic of Mauritania
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: Republic of Malta
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: Republic of Mauritius
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldives
       official_name: Republic of Maldives
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: Republic of Malawi
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Mexico
       official_name: United Mexican States
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malaysia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambique
       official_name: Republic of Mozambique
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibia
       official_name: Republic of Namibia
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: New Caledonia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: Republic of the Niger
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk Island
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: Federal Republic of Nigeria
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: Republic of Nicaragua
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Netherlands
       official_name: Kingdom of the Netherlands
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norway
       official_name: Kingdom of Norway
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: Federal Democratic Republic of Nepal
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: Republic of Nauru
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: Niue
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: New Zealand
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
       official_name: Sultanate of Oman
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: Republic of Panama
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: Republic of Peru
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: French Polynesia
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua New Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Philippines
       official_name: Republic of the Philippines
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: Islamic Republic of Pakistan
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Poland
       official_name: Republic of Poland
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint Pierre and Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestinian Territory, Occupied
       official_name: Occupied Palestinian Territory
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: Portuguese Republic
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: Republic of Palau
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: Republic of Paraguay
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: State of Qatar
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Réunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Romania
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Serbia
       official_name: Republic of Serbia
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Russian Federation
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Rwanda
       official_name: Rwandese Republic
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saudi Arabia
       official_name: Kingdom of Saudi Arabia
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Solomon Islands
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychelles
       official_name: Republic of Seychelles
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: Republic of the Sudan
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Sweden
       official_name: Kingdom of Sweden
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapore
       official_name: Republic of Singapore
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Saint Helena, Ascension and Tristan da Cunha
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovenia
       official_name: Republic of Slovenia
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard and Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovakia
       official_name: Slovak Republic
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: Republic of Sierra Leone
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: Republic of San Marino
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: Republic of Senegal
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
       official_name: Somali Republic
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: Republic of Suriname
+      nationality: !!null 
     ss:
       common_name: !!null 
       name: South Sudan
       official_name: Republic of South Sudan
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Sao Tome and Principe
       official_name: Democratic Republic of Sao Tome and Principe
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: Republic of El Salvador
+      nationality: !!null 
     sx:
       common_name: !!null 
       name: Sint Maarten (Dutch part)
       official_name: Sint Maarten (Dutch part)
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syrian Arab Republic
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Swaziland
       official_name: Kingdom of Swaziland
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks and Caicos Islands
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chad
       official_name: Republic of Chad
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: French Southern Territories
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: Togolese Republic
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thailand
       official_name: Kingdom of Thailand
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tajikistan
       official_name: Republic of Tajikistan
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timor-Leste
       official_name: Democratic Republic of Timor-Leste
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunisia
       official_name: Republic of Tunisia
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: Kingdom of Tonga
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turkey
       official_name: Republic of Turkey
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad and Tobago
       official_name: Republic of Trinidad and Tobago
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: Taiwan
       name: Taiwan, Province of China
       official_name: Taiwan, Province of China
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzania, United Republic of
       official_name: United Republic of Tanzania
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukraine
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: Republic of Uganda
+      nationality: !!null 
     um:
       common_name: !!null 
       name: United States Minor Outlying Islands
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: United States
       official_name: United States of America
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: Eastern Republic of Uruguay
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistan
       official_name: Republic of Uzbekistan
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Holy See (Vatican City State)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Saint Vincent and the Grenadines
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: Venezuela
       name: Venezuela, Bolivarian Republic of
       official_name: Bolivarian Republic of Venezuela
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Virgin Islands, British
       official_name: British Virgin Islands
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Virgin Islands, U.S.
       official_name: Virgin Islands of the United States
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Viet Nam
       official_name: Socialist Republic of Viet Nam
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: Republic of Vanuatu
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis and Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: Independent State of Samoa
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Yemen
       official_name: Republic of Yemen
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: South Africa
       official_name: Republic of South Africa
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambia
       official_name: Republic of Zambia
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: Republic of Zimbabwe
+      nationality: !!null 

--- a/locale/es/world.yml
+++ b/locale/es/world.yml
@@ -5,887 +5,1109 @@ es:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Emiratos Árabes Unidos
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua y Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguila
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albania
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenia
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Antillas Neerlandesas
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Samoa Estadounidense
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Austria
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australia
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Åland
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaiyán
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnia y Herzegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladés
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Bélgica
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgaria
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Baréin
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benín
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: San Bartolomé
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermudas
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunéi
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivia
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brasil
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bután
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Isla Bouvet
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botsuana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Bielorrusia
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belice
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Canadá
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Islas Cocos
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Rep. Dem. del Congo
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: República Centroafricana
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: República del Congo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Suiza
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Costa de Marfil
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Islas Cook
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Camerún
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: China
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Colombia
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Cuba
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Isla de Navidad
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Chipre
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: República Checa
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Alemania
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Yibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dinamarca
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: República Dominicana
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Argelia
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonia
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egipto
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: España
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiopía
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finlandia
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fiyi
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Islas Malvinas
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Micronesia
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Francia
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Reino Unido
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Granada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgia
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Guayana Francesa
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Groenlandia
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadalupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Guinea Ecuatorial
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Grecia
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Islas Georgias del Sur y Sandwich del Sur
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Islas Heard y McDonald
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Croacia
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Hungría
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesia
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irlanda
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israel
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isla de Man
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Territorio Británico del Océano Índico
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Irán
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Islandia
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italia
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordania
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japón
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenia
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirguistán
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Camboya
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Comoras
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: San Cristóbal y Nieves
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Corea del Norte
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Corea del Sur
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Islas Caimán
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Líbano
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Santa Lucía
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesoto
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Lituania
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxemburgo
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Letonia
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libia
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marruecos
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Mónaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldavia
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: San Martín
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagascar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Islas Marshall
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: República de Macedonia
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Malí
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Birmania
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolia
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Islas Marianas del Norte
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinica
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritania
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauricio
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldivas
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malaui
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: México
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malasia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambique
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nueva Caledonia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Níger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Países Bajos
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Noruega
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nueva Zelanda
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panamá
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Perú
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Polinesia Francesa
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papúa Nueva Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipinas
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistán
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polonia
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: San Pedro y Miquelón
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Islas Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Autoridad Nacional Palestina
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palaos
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunión
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Rumania
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Serbia
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Rusia
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Arabia Saudita
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Islas Salomón
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychelles
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudán
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Suecia
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Santa Helena, A. y T.
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Eslovenia
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard y Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Eslovaquia
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leona
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Surinam
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Santo Tomé y Príncipe
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Siria
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Suazilandia
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Islas Turcas y Caicos
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Territorios Australes Franceses
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tayikistán
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timor Oriental
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistán
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Túnez
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turquía
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad y Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Taiwán
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzania
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Estados Unidos
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistán
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Ciudad del Vaticano
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: San Vicente y las Granadinas
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Islas Vírgenes Británicas
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Islas Vírgenes de los Estados Unidos
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Sudáfrica
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabue
       official_name: !!null 
+      nationality: !!null 

--- a/locale/fi/world.yml
+++ b/locale/fi/world.yml
@@ -5,1011 +5,1264 @@ fi:
       common_name: !!null 
       name: Ascension Island
       official_name: !!null 
+      nationality: !!null 
     ad:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Arabiemiirikunnat
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afganistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua ja Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albania
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenia
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Alankomaiden Antillit
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktis
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentiina
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Amerikan Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Itävalta
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australia
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Ahvenanmaa
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaidžan
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnia ja Hertsegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgia
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgaria
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrain
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivia
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brasilia
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahama
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouvet’nsaari
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Valko-Venäjä
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Kookossaaret
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongon demokraattinen tasavalta
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Keski-Afrikan tasavalta
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Kongon tasavalta
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Sveitsi
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Norsunluurannikko
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cookinsaaret
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: Kiina
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolumbia
       official_name: !!null 
+      nationality: !!null 
     cp:
       common_name: !!null 
       name: Clippertoninsaari
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Kuuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Kap Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Joulusaari
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Kypros
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Tšekki
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Saksa
       official_name: !!null 
+      nationality: !!null 
     dg:
       common_name: !!null 
       name: Diego Garcia
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Djibouti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Tanska
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominikaaninen tasavalta
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algeria
       official_name: !!null 
+      nationality: !!null 
     ea:
       common_name: !!null 
       name: Ceuta, Melilla
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Viro
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egypti
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Länsi-Sahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Espanja
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiopia
       official_name: !!null 
+      nationality: !!null 
     eu:
       common_name: !!null 
       name: Euroopan unioni
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Suomi
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fidži
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandinsaaret
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronesian liittovaltio
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Färsaaret
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Ranska
       official_name: !!null 
+      nationality: !!null 
     fx:
       common_name: !!null 
       name: Ranska (Eurooppaan kuuluvat osat)
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Yhdistynyt kuningaskunta
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgia
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Ranskan Guayana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grönlanti
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Päiväntasaajan Guinea
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Kreikka
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Etelä-Georgia ja Eteläiset Sandwichsaaret
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hongkong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heard ja McDonaldinsaaret
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Kroatia
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Unkari
       official_name: !!null 
+      nationality: !!null 
     ic:
       common_name: !!null 
       name: Kanariansaaret
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesia
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irlanti
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israel
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Mansaari
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Intia
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Brittiläinen Intian valtameren alue
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Islanti
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italia
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaika
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordania
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japani
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenia
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirgisia
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kambodža
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komorit
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Saint Kitts ja Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Korean demokraattinen kansantasavalta
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Korean tasavalta
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Caymansaaret
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazakstan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Liettua
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxemburg
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Latvia
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libya
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marokko
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldova
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshallinsaaret
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Makedonia
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolia
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Pohjois-Mariaanit
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinique
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritania
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Malediivit
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Meksiko
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malesia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mosambik
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibia
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Uusi-Kaledonia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolkinsaari
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Alankomaat
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norja
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Uusi-Seelanti
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Ranskan Polynesia
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua-Uusi-Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filippiinit
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Puola
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint-Pierre ja Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestiina
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugali
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Réunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Romania
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Serbia
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Venäjä
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saudi-Arabia
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Salomonsaaret
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychellit
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Ruotsi
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapore
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Saint Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovenia
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard ja Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovakia
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: São Tomé ja Príncipe
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syyria
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Swazimaa
       official_name: !!null 
+      nationality: !!null 
     ta:
       common_name: !!null 
       name: Tristan da Cunha
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks- ja Caicossaaret
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Tšad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Ranskan eteläiset alueet
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thaimaa
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tadžikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Itä-Timor
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunisia
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turkki
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad ja Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Taiwan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tansania
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukraina
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     uk:
       common_name: !!null 
       name: Yhdistynyt kuningaskunta
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Yhdysvaltain Tyynenmeren erillissaaret
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Yhdysvallat
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Vatikaanivaltio
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Saint Vincent ja Grenadiinit
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Brittiläiset Neitsytsaaret
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Yhdysvaltain Neitsytsaaret
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis ja Futunasaaret
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Etelä-Afrikka
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Sambia
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: !!null 

--- a/locale/hi/world.yml
+++ b/locale/hi/world.yml
@@ -5,979 +5,1224 @@ hi:
       common_name: !!null 
       name: अनडोरा
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: संयुक्त अरब अमीरात
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: अफ़ग़ानिस्तान
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: एंटीगुआ और बारबुडा
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: एंगुइला
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: अल्बानिया
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: आर्मेनिया
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: नीदरलैंड एंटिल्स
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: अंगोला
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: अंटार्कटिका
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: अर्जेंटीना
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: अमेरिकन समोआ
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: ऑस्ट्रिया
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: ऑस्ट्रेलिया
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: अरूबा
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: आलैंड द्वीप
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: अज़रबैजान
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: बोस्निया और हरज़ेगोविना
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: बारबाडोस
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: बांग्लादेश
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: बेल्जियम
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: बुर्किना फासो
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: बुल्गारिया
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: बहरीन
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: बुस्र्न्दी
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: बेनिन
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: बरमूडा
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: ब्रुनेई दारुसलाम
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: बोलीविया
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: ब्राज़िल
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: बहामा
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: भूटान
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: बुवेत आइलैंड
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: बोत्सवाना
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: बेलारूस
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: बेलीज
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: कनाडा
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: क्रिसमस द्वीप
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: कांगो लोकतांत्रिक गणराज्य
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: मध्य अफ्रीकी गणराज्य
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: कांगो
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: स्विट्जरलैंड
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: कोटे डी आइवर
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: कुक द्वीपसमूह
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: चिली
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: कैमरून
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: चीन
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: कोलम्बिया
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: कोस्टा रिका
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: क्यूबा
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: केप वर्ड
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: क्रिसमस द्वीप
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: साइप्रस
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: चेक गणराज्य
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: जर्मनी
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: जिबूती
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: डेनमार्क
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: डोमिनिका
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: डोमिनिकन गणराज्य
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: एलजीरिया
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: इक्वेडोर
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: एस्तोनिया
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: मिस्र
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: पश्चिमी सहारा
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: इरिट्रिया
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: स्पेन
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: इथियोपिया
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: फिनलैंड
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: फिजी
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: फ़ॉकलैंड द्वीप (माल्विनास)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: माइक्रोनेशिया, फ़ेडरेटेड राज्यों की
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: फरो आइलैंड्स
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: फ्रांस
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: गैबॉन
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: यूनाइटेड किंगडम
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: ग्रेनाडा
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: जॉर्जिया
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: फ्रेंच गयाना
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: ग्वेर्नसे
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: घाना
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: जिब्राल्टर
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: ग्रीनलैंड
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: गाम्बिया
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: गिनी
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: गुआदेलूप
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: इक्वेटोरियल गिनी
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: ग्रीस
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: दक्षिण जॉर्जिया और दक्षिण सैंडविच द्वीप
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: ग्वाटेमाला
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: गुआम
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: गिनी बिसाऊ
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: गुयाना
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: हांगकांग
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: हर्ड आइलैंड और मैकडोनाल्ड आइलैंड्स
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: होंडुरस
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: क्रोएशिया
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: हैती
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: हंगरी
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: इंडोनेशिया
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: आयरलैंड
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: इजराइल
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: आइल ऑफ मैन
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: भारत
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: ब्रिटिश हिंद महासागरीय क्षेत्र
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: इराक
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: ईरान के इस्लामी गणराज्य
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: आइसलैंड
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: इटली
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: जर्सी
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: जमैका
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: जॉर्डन
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: जापान
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: केन्या
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: किर्गिस्तान
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: कंबोडिया
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: किरिबाती
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: कोमोरोस
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: सेंट किट्स और नेविस
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: कोरिया, डेमोक्रेटिक पीपुल्स रिपब्लिक ऑफ
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: कोरिया, गणराज्य के
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: कोसोवो
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: कुवैत
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: केमैन आइलैंड्स
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: कजाखस्तान
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: लाओ जनवादी लोकतांत्रिक गणराज्य
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: लेबनान
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: सेंट लूसिया
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: लिकटेंस्टीन
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: श्रीलंका
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: लीबेरिअ
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: लिसोटो
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: लिथुआनिया
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: लक्ज़मबर्ग
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: लातविया
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: लिबियाई अरब जमहीरिया
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: मोरक्को
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: मोनाको
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: मोल्डाविया गणतंत्र का
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: मोंटेनेग्रो
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: मैडागास्कर
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: मार्शल द्वीप
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: मैसिडोनिया, पूर्वयूगोस्लाव गणराज्य
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: माली
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: मंगोलिया
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: मकाऊ
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: उत्तरी मारियाना द्वीप
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: मार्टीनिक
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: मॉरिटानिया
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: मॉन्ट्सेराट
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: माल्टा
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: मॉरिशस
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: मालदीव
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: मलावी
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: मेक्सिको
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: मलेशिया
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: मोज़ाम्बिक
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: नामीबिया
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: न्यू कैलेडोनिया
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: नाइजर
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: नॉरफ़ॉक द्वीप
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: नाइजीरिया
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: निकारागुआ
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: नीदरलैंड्स
       official_name: !!null 
+      nationality: !!null 
     nm:
       common_name: !!null 
       name: म्यांमार
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: नॉर्वे
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: नेपाल
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: नाउरू
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: नीयू
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: न्यूजीलैंड
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: ओमान
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: पनामा
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: पेरू
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: फ्रेंच पोलीनेशिया
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: पापुआ न्यू गिनी
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: फिलीपींस
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: पाकिस्तान
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: पोलैंड
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: सेंट पियरे और मिकेलॉन
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: पिटकैर्न
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: पर्टो रीको
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: फ़िलिस्तीन, कब्जे
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: पुर्तगाल
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: पलाऊ
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: पारागुए
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: कतर
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: रीयूनियन
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: रोमानिया
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: सर्बिया
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: रूसी संघ
       official_name: !!null 
+      nationality: !!null 
     rwू:
       common_name: !!null 
       name: रवांडा
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: सऊदी अरब
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: सोलोमन द्वीप
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: सेशेल्स
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: सूडान
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: स्वीडन
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: सिंगापुर
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: सेंट हेलेना
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: स्लोवेनिया
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: स्वालबर्ड और जन मायेन
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: स्लोवाकिया
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: सिएरा लियोन
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: सैन मैरिनो
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: सेनेगल
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: सोमालिया
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: सूरीनाम
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: साओ टोम और प्रिंसिपे
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: अल साल्वाडोर
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: सीरिया अरब गणराज्य
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: स्वाज़ीलैंड
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: तुर्क एंड कोइकोस आइलैंड्स
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: काग़ज़ का टुकड़ा
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: फ़्रांसीसी दक्षिणी क्षेत्र
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: टोगो
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: थाईलैंड
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: ताजिकिस्तान
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: टोकेलौ
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: तिमोर-लेस्ते
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: तुर्कमेनिस्तान
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: टुनिशिया
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: टोंगा
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: टर्की
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: त्रिनिदाद और टोबैगो
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: तुवालु
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: ताइवान, चीन के प्रांत
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: तंजानिया, संयुक्त गणराज्य
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: यूक्रेन
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: युगांडा
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: यूनाइटेड स्टेट्स माइनर आउटलाइंग द्वीपसमूह
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: संयुक्त राज्य अमेरिका
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: उरुग्वे
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: उजबेकिस्तान
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: होली सी (वैटिकन सिटी राज्य)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: सेंट विन्सेंट और ग्रेनाडीन्स
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: वेनेजुएला
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: वर्जिन आइलैंड्स, ब्रिटिश
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: वर्जिन द्वीप समूह, अमेरिका
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: वियतनाम
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: वानुअतु
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: वालिस और फ़्यूचूना
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: समोआ
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: यमन
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: मैयट
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: दक्षिण अफ्रीका
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: जाम्बिया
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: जिम्बाब्वे
       official_name: !!null 
+      nationality: !!null 

--- a/locale/it/world.yml
+++ b/locale/it/world.yml
@@ -5,951 +5,1189 @@ it:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Emirati arabi uniti
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afghanistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua e Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albania
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenia
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Antille olandesi
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antartide
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Samoa americane
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Austria
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australia
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaigian
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnia-Erzegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgio
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgaria
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrein
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivia
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brasile
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamas
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Isola Bouvet
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Bielorussia
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Canada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Isole Cocos
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Congo (ex Zaire)
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Repubblica Centrafricana
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Congo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Svizzera
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Costa d'Avorio
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Isole Cook
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Cile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Camerun
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: Cina
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Colombia
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Cuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Capo Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Isola Christmas
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Cipro
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Repubblica ceca
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Germania
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Gibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Danimarca
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Repubblica dominicana
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algeria
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonia
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egitto
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Sahara occidentale
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Spagna
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiopia
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finlandia
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Figi
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Isole Falkland
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Micronesia
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Faerøerne
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Francia
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Gran Bretagna
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgia
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Guiana francese
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibilterra
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Groenlandia
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadalupa
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Guinea Equatoriale
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Grecia
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Isole Georgia del Sud e Sandwich del Sud
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Isole Heard e McDonald
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Croazia
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Ungheria
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesia
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irlanda
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israele
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: India
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Territorio britannico dell'Oceano Indiano
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Iraq
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Islanda
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italia
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Giamaica
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Giordania
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Giappone
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenya
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirghizistan
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Cambogia
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Comore
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Saint Christopher e Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Corea del Nord
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Corea del Sud
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Isole Cayman
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazakistan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libano
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Lituania
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Lussemburgo
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Lettonia
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libia
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marocco
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldavia
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagascar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Isole Marshall
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedonia
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolia
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Marianne settentrionali
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinica
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritania
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Monserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldive
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Messico
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malesia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambico
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibia
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nuova Caledonia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Isola Norfolk
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Paesi Bassi
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norvegia
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nuova Zelanda
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Perù
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Polinesia francese
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua Nuova Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filippine
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polonia
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint-Pierre e Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Isole Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Portorico
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portogallo
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Riunione
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Romania
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Russia
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Arabia Saudita
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Isole Salomone
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seicelle
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Svezia
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapore
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Sant'Elena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovenia
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard e Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovacchia
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: São Tomé e Príncipe
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Siria
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Swaziland
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Isole Turks e Caicos
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Ciad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Territori australi francesi
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thailandia
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tagikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timor orientale
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunisia
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turchia
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad e Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Taiwan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzania
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ucraina
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Isole minori lontane dagli Stati Uniti
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Stati Uniti
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Vaticano
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Saint Vincent e Grenadine
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Isole Vergini britanniche
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Isole Vergini americane
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis e Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Yemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     yu:
       common_name: !!null 
       name: Iugoslavia
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Sudafrica
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambia
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: !!null 

--- a/locale/jp/world.yml
+++ b/locale/jp/world.yml
@@ -5,979 +5,1224 @@ jp:
       common_name: !!null 
       name: アンドラ
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: アラブ首長国連邦
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: アフガニスタン
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: アンティグア・バーブーダ
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: アンギラ
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: アルバニア
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: アルメニア
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: オランダ領アンティル
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: アンゴラ
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: 南極
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: アルゼンチン
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: アメリカ領サモア
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: オーストリア
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: オーストラリア
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: アルバ
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: オーランド諸島
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: アゼルバイジャン
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: ボスニア・ヘルツェゴビナ
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: バルバドス
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: バングラデシュ
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: ベルギー
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: ブルキナファソ
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: ブルガリア
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: バーレーン
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: ブルンジ
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: ベナン
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: バミューダ諸島
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: ブルネイ
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: ボリビア
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: ブラジル
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: バハマ
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: ブータン
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: ブーベ島
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: ボツワナ
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: ベラルーシ
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: ベリーズ
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: カナダ
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: ココス諸島
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: コンゴ民主共和国
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: 中央アフリカ
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: コンゴ共和国
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: スイス
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: コートジボワール
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: クック諸島
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: チリ
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: カメルーン
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: 中華人民共和国
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: コロンビア
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: コスタリカ
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: キューバ
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: カーボベルデ
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: クリスマス島
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: キプロス
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: チェコ
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: ドイツ
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: ジブチ
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: デンマーク
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: ドミニカ国
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: ドミニカ共和国
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: アルジェリア
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: エクアドル
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: エストニア
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: エジプト
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: 西サハラ
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: エリトリア
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: スペイン
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: エチオピア
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: フィンランド
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: フィジー
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: フォークランド諸島
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: ミクロネシア連邦
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: フェロー諸島
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: フランス
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: ガボン
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: イギリス
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: グレナダ
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: グルジア
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: フランス領ギアナ
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: ガーンジー
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: ガーナ
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: ジブラルタル
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: グリーンランド
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: ガンビア
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: ギニア
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: グアドループ
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: 赤道ギニア
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: ギリシャ
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: サウスジョージア・サウスサンドウィッチ諸島
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: グアテマラ
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: グアム
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: ギニアビサウ
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: ガイアナ
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: 香港
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: ハード島とマクドナルド諸島
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: ホンジュラス
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: クロアチア
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: ハイチ
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: ハンガリー
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: インドネシア
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: アイルランド
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: イスラエル
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: マン島
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: インド
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: イギリス領インド洋地域
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: イラク
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: イラン
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: アイスランド
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: イタリア
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: ジャージー
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: ジャマイカ
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: ヨルダン
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: 日本
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: ケニア
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: キルギス
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: カンボジア
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: キリバス
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: コモロ
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: セントクリストファー・ネイビス
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: 朝鮮民主主義人民共和国
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: 大韓民国
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: コソボ
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: クウェート
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: ケイマン諸島
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: カザフスタン
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: ラオス
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: レバノン
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: セントルシア
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: リヒテンシュタイン
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: スリランカ
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: リベリア
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: レソト
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: リトアニア
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: ルクセンブルク
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: ラトビア
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: リビア
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: モロッコ
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: モナコ
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: モルドバ
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: モンテネグロ
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: マダガスカル
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: マーシャル諸島
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: マケドニア共和国
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: マリ
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: ミャンマー
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: モンゴル
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: マカオ
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: 北マリアナ諸島
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: マルティニーク
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: モーリタニア
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: モントセラト
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: マルタ
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: モーリシャス
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: モルディブ
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: マラウイ
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: メキシコ
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: マレーシア
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: モザンビーク
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: ナミビア
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: ニューカレドニア
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: ニジェール
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: ノーフォーク島
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: ナイジェリア
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: ニカラグア
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: オランダ
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: ノルウェー
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: ネパール
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: ナウル
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: ニウエ
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: ニュージーランド
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: オマーン
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: パナマ
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: ペルー
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: フランス領ポリネシア
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: パプアニューギニア
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: フィリピン
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: パキスタン
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: ポーランド
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: サンピエール島・ミクロン島
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: ピトケアン
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: プエルトリコ
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: パレスチナ
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: ポルトガル
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: パラオ
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: パラグアイ
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: カタール
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: レユニオン
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: ルーマニア
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: セルビア
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: ロシア
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: ルワンダ
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: サウジアラビア
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: ソロモン諸島
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: セーシェル
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: スーダン
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: スウェーデン
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: シンガポール
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: セントヘレナ
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: スロベニア
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: スヴァールバル諸島およびヤンマイエン島
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: スロバキア
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: シエラレオネ
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: サンマリノ
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: セネガル
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: ソマリア
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: スリナム
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: サントメ・プリンシペ
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: エルサルバドル
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: シリア
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: スワジランド
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: タークス・カイコス諸島
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: チャド
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: フランス領南方・南極地域
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: トーゴ
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: タイ
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: タジキスタン
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: トケラウ
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: 東ティモール
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: トルクメニスタン
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: チュニジア
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: トンガ
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: トルコ
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: トリニダード・トバゴ
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: ツバル
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: 台湾
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: タンザニア
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: ウクライナ
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: ウガンダ
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: 合衆国領有小離島
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: アメリカ合衆国
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: ウルグアイ
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: ウズベキスタン
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: バチカン
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: セントビンセント・グレナディーン
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: ベネズエラ
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: イギリス領ヴァージン諸島
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: アメリカ領ヴァージン諸島
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: ベトナム
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: バヌアツ
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: ウォリス・フツナ
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: サモア
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: イエメン
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: マヨット
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: 南アフリカ
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: ザンビア
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: ジンバブエ
       official_name: !!null 
+      nationality: !!null 

--- a/locale/ko/world.yml
+++ b/locale/ko/world.yml
@@ -5,951 +5,1189 @@ ko:
       common_name: !!null 
       name: 안도라
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: 아랍에미리트연합국
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: 아프카니스탄
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: 앤티가바부다
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: 앙길라
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: 알바니아
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: 아르메니아
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: 네덜란드령 안틸레스
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: 앙골라
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: 남극
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: 아르헨티나
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: 미국령 사모아
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: 오스트리아
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: 호주
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: 아루바
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: 아제르바이잔
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: 보스니아 헤르체고비나
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: 바베이도스
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: 방글라데시
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: 벨기에
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: 부르키나 파소
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: 불가리아
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: 바레인
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: 부룬디
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: 베냉
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: 버뮤다
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: 브루나이
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: 볼리비아
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: 브라질
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: 바하마
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: 부탄
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: 부베섬
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: 보츠와나
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: 벨로루시
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: 벨리즈
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: 캐나다
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: 코코스 (킬링) 제도
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: 콩고 민주 공화국
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: 중앙아프리카공화국
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: 콩고
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: 스위스
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: 코트디부와르
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: 쿡 제도
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: 칠레
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: 카메룬
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: 중국
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: 콜럼비아
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: 코스타리카
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: 쿠바
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: 카보베르데
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: 크리스마스 섬
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: 키프로스
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: 체코 공화국
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: 독일
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: 지부티
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: 덴마크
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: 도미니카
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: 도미니카 공화국
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: 알제리아
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: 에쿠아도르
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: 에스토니아
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: 이집트
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: 서부 사하라
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: 에리트레아
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: 스페인
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: 에티오피아
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: 핀란드
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: 피지
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: 포크랜드 군도(말비나스)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: 마이크로네시아 연합국
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: 페로우 군도
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: 프랑스
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: 가봉
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: 영국
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: 그레나다
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: 그루지야
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: 프랑스령 가이아나
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: 가나
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: 지브랄타
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: 그린랜드
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: 감비아
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: 기니
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: 과들루프
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: 적도 기니
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: 그리스
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: 과테말라
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: 괌
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: 기니비사우
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: 가이아나
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: 홍콩
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: 허드 및 맥도날드 군도
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: 온두라스
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: 크로아티아
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: 하이티
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: 헝가리
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: 인도네시아
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: 아일랜드
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: 이스라엘
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: 인도
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: 영국령 인도양 식민지
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: 이라크
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: 이란
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: 아이슬란드
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: 이탈리아
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: 자메이카
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: 요르단
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: 일본
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: 케냐
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: 키르기스
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: 캄보디아
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: 키리바시
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: 코모로
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: 세인트키츠네비스
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: 북한
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: 대한민국
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: 쿠웨이트
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: 케이맨 군도
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: 카자흐스탄
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: 라오스
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: 레바논
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: 세인트 루치아
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: 리히텐슈타인
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: 스리랑카
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: 라이베리아
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: 레소토
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: 리투아니아
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: 룩셈부르크
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: 라트비아
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: 리비아
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: 모로코
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: 모나코
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: 몰도바
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: 몬테네그로
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: 마다가스카르
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: 마셜 제도
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: 마케도니아
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: 말리
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: 미얀마
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: 몽골
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: 마카오
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: 북 마리아나 제도
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: 마르티니크
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: 모리타니아
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: 몬트세라트
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: 몰타
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: 모리셔스
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: 말라위
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: 몰디브
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: 멕시코
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: 말레이시아
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: 모잠비크
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: 나미비아
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: 뉴 칼레도니아
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: 니제르
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: 노퍽 제도
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: 나이제리아
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: 니카라과
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: 네덜란드
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: 노르웨이
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: 네팔
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: 나우루
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: 니우에
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: 뉴질랜드
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: 오만
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: 파나마
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: 페루
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: 프랑스령 폴리네시아
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: 파푸아뉴기니
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: 필리핀
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: 파키스탄
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: 폴란드
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: 성 피에르 및 미클롱
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: 핏케언
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: 푸에르토리코
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: 포르투갈
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: 팔라우
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: 파라과이
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: 카타르
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: 리유니온
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: 루마니아
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: 세르비아
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: 러시아
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: 르완다
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: 사우디 아라비아
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: 솔로몬 제도
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: 세이셸
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: 수단
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: 스웨덴
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: 싱가포르
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: 세인트 헬레나
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: 슬로베니아
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: 스발바드 및 얀마옌
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: 슬로바키아
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: 시에라리온
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: 산마리노
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: 세네갈
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: 소말리아
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: 수리남
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: 상투메 프린시페
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: 엘살바도르
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: 시리아
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: 스와질란드
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: 터크스 앤드 카이코스 제도
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: 차드
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: 프랑스령 남부 영토
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: 토고
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: 태국
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: 타지키스탄
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: 토켈라우
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: 티모르-레스테
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: 투르크메니스탄
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: 튀니지
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: 통가
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: 터키
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: 트리니다드 토바고
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: 투발루
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: 대만
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: 탄자니아
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: 우크라이나
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: 우간다
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: 미국령 군소 외곽제도
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: 미국
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: 우루과이
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: 우즈베키스탄
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: 바티칸 시(교황청)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: 세인트 빈센트 그레나딘
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: 베네수엘라
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: 영국령 버진 제도
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: 미국령 버진 제도
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: 베트남
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: 바누아투
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: 월리스 푸투나
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: 사모아
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: 예멘
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: 마요테
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: 남아프리카
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: 잠비아
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: 짐바브웨
       official_name: !!null 
+      nationality: !!null 

--- a/locale/nl/world.yml
+++ b/locale/nl/world.yml
@@ -5,999 +5,1249 @@ nl:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Verenigde Arabische Emiraten
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afghanistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua en Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albanië
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenië
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Nederlandse Antillen
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarctica
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentinië
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Amerikaans Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Oostenrijk
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australië
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Alandeilanden
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbeidzjan
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosnië en Herzegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: België
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgarije
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrein
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint Barthélemy
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivia
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brazilië
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahama’s
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouveteiland
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Wit-Rusland
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Canada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Cocoseilanden
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Congo-Kinshasa
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Centraal-Afrikaanse Republiek
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Congo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Zwitserland
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Ivoorkust
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cookeilanden
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chili
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kameroen
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: China
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Colombia
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cs:
       common_name: !!null 
       name: Servië en Montenegro
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Cuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Kaapverdië
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Christmaseiland
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Cyprus
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Tsjechië
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Duitsland
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Djibouti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Denemarken
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominicaanse Republiek
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algerije
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estland
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egypte
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Westelijke Sahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Spanje
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Ethiopië
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finland
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fiji
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandeilanden
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Micronesië
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Faeröer
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Frankrijk
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Verenigd Koninkrijk
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Georgië
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Frans-Guyana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Groenland
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinee
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Equatoriaal-Guinea
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Griekenland
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Zuid-Georgië en Zuidelijke Sandwicheilanden
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinee-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hongkong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heard- en McDonaldeilanden
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Kroatië
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haïti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Hongarije
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonesië
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Ierland
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israël
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isle of Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: India
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Britse Gebieden in de Indische Oceaan
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: IJsland
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Italië
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaica
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordanië
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japan
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenia
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirgizië
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Cambodja
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Comoren
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Saint Kitts en Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Noord-Korea
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Zuid-Korea
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Koeweit
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Caymaneilanden
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazachstan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litouwen
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxemburg
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Letland
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libië
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marokko
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldavië
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Sint-Maarten
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshalleilanden
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedonië
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolië
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Noordelijke Marianeneilanden
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinique
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritanië
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldiven
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Mexico
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Maleisië
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambique
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibië
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nieuw-Caledonië
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolkeiland
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Nederland
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Noorwegen
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nieuw-Zeeland
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Frans-Polynesië
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papoea-Nieuw-Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipijnen
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polen
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint Pierre en Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestijns Gebied
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: !!null 
+      nationality: !!null 
     qo:
       common_name: !!null 
       name: Oceanië (overige)
       official_name: !!null 
+      nationality: !!null 
     qu:
       common_name: !!null 
       name: Europese Unie
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Réunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Roemenië
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Servië
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Rusland
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Rwanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saoedi-Arabië
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Salomonseilanden
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychellen
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Soedan
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Zweden
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapore
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Sint-Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovenië
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard en Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slowakije
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalië
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Sao Tomé en Principe
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syrië
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Swaziland
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks- en Caicoseilanden
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Tsjaad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Franse Gebieden in de zuidelijke Indische Oceaan
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thailand
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tadzjikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Oost-Timor
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunesië
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turkije
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad en Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Taiwan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzania
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Oekraïne
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Oeganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Amerikaanse kleinere afgelegen eilanden
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Verenigde Staten
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Oezbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Vaticaanstad
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Saint Vincent en de Grenadines
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Britse Maagdeneilanden
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Amerikaanse Maagdeneilanden
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis en Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Zuid-Afrika
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambia
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: !!null 
     zz:
       common_name: !!null 
       name: Onbekend of onjuist gebied
       official_name: !!null 
+      nationality: !!null 

--- a/locale/pl/world.yml
+++ b/locale/pl/world.yml
@@ -4,980 +4,1225 @@ pl:
     ad:
       common_name: !!null 
       name: Andora
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Zjednoczone Emiraty Arabskie
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afganistan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua i Barbuda
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albania
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armenia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Antyle Holenderskie
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktyda
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentyna
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Samoa Amerykańskie
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Austria
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Australia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Wyspy Alandzkie
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbejdżan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bośnia i Hercegowina
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesz
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bułgaria
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrajn
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint Barthelemy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermudy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei Darussalam
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Boliwia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brazylia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Wyspa Bouveta
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Białoruś
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Wyspy Kokosowe (Keelinga)
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongo, Demokratyczna Republika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Republika Środkowej Afryki
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Kongo
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Szwajcaria
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Wybrzeże Kości Słoniowej
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Wyspy Cooka
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: Chiny
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolumbia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Kostaryka
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Kuba
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Wyspy Zielonego Przylądka
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Wyspa Bożego Narodzenia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Cypr
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Republika Czeska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Niemcy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Dżibuti
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dania
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Tonga
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Algieria
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egipt
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Sahara Zachodnia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Erytrea
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Hiszpania
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiopia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finlandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fidżi
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandy (Malwiny)
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronezja z
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Francja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Wielka Brytania
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Gruzja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Gujana Francuska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grenlandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Gwinea
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Gwadelupa
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Gwinea Równikowa
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Grecja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Georgia Południowa i Sandwich Południowy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Gwatemala
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Gwinea Bissau
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Gujana
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Wyspy Heard i McDonalda Wyspy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Chorwacja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Węgry
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonezja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irlandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Izrael
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isle of Man
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Brytyjskie Terytorium Oceanu Indyjskiego
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iran, Islamska Republika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Islandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Włochy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamajka
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japonia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirgistan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kambodża
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komory
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Saint Kitts i Nevis
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Korea Ludowo-Demokratyczna Republika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Republika Korei
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Kosowo
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwejt
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Kajmany
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazachstan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Ludzie Lao Demokratycznej Republiki
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Liban
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litwa
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luksemburg
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Łotwa
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Maroko
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Mołdawia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Czarnogóra
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Saint Martin (francuska część I)
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Wyspy Marshalla
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedonia, Była Jugosłowiańska Republika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Makau
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Mariany Północne
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martynika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauretania
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Malediwy
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Meksyk
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Polska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambik
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nowa Kaledonia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigeria
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nikaragua
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Holandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norwegia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nowa Zelandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Oman
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Polinezja Francuska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua-Nowa Gwinea
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipiny
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Polska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint Pierre i Miquelon
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Okupowane Terytorium Palestyny
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugalia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paragwaj
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Katar
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunion
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Rumunia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Serbia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Federacja Rosyjska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Rwanda
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Arabia Saudyjska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Wyspy Salomona
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seszele
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Szwecja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Święta Helena
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Słowenia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard i Jan Mayen
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Słowacja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somalia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Surinam
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Sao Tome i Principe
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Syryjska Republika Arabska
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Suazi
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks i Caicos
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chad
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Francuskie Terytoria Południowe
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Tajlandia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tadżykistan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timorze Wschodnim
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkmenistan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunezja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turcja
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trynidad i Tobago
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Tajwan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzania, Zjednoczona Republika
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukraina
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Stany Zjednoczone Dalekie Wyspy Mniejsze
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     usa:
       common_name: !!null 
       name: Stany Zjednoczone
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Urugwaj
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistan
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Stolicy Apostolskiej (Państwa Watykańskiego)
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Saint Vincent i Grenadyny
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Wenezuela
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Brytyjskie Wyspy Dziewicze
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Wyspy Dziewicze Stanów Zjednoczonych
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Wietnam
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     w:
       common_name: !!null 
       name: Indie
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     we:
       common_name: !!null 
       name: Ekwador
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis i Futuna
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Majotta
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: RPA
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambia
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
-      official_name: !!null 
+      official_name: 
+      nationality: !!null 

--- a/locale/pt/world.yml
+++ b/locale/pt/world.yml
@@ -5,1011 +5,1264 @@ pt:
       common_name: !!null 
       name: Ascensão
       official_name: !!null 
+      nationality: !!null 
     ad:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Emirados Árabes Unidos
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afeganistão
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antígua e Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilha
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albânia
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Armênia
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Antilhas Holandesas
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antártica
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Samoa Americana
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Áustria
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Austrália
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Ilhas Åland
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaijão
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bósnia e Herzegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Bélgica
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgária
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrein
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: São Bartolomeu
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolívia
       official_name: !!null 
+      nationality: !!null 
     bq:
       common_name: !!null 
       name: Bonaire, Sint Eustatius e Saba
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brasil
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamas
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Butão
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Ilha Bouvet
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botsuana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Bielorrússia
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Canadá
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Ilhas Cocos
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: República Democrática do Congo
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: República Centro-Africana
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: República do Congo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Suíça
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Costa do Marfim
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Ilhas Cook
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Camarões
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: China
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Colômbia
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Cuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Cabo Verde
       official_name: !!null 
+      nationality: !!null 
     cw:
       common_name: !!null 
       name: Curaçao
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Ilha Christmas
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Chipre
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: República Tcheca
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Alemanha
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Djibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dinamarca
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: República Dominicana
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Argélia
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Equador
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estônia
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egito
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Saara Ocidental
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritreia
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Espanha
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiópia
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finlândia
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fiji
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Ilhas Malvinas
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Estados Federados da Micronésia
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Ilhas Faroe
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: França
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabão
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Reino Unido
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Granada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Geórgia
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Guiana Francesa
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernesei
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Gana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Groelândia
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gâmbia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guiné
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadalupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Guiné Equatorial
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Grécia
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Ilhas Geórgia do Sul e Sandwich do Sul
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guiné-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guiana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Ilha Heard e Ilhas McDonald
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Croácia
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Hungria
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonésia
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Irlanda
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Israel
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Ilha de Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Índia
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Território Britânico do Oceano Índico
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Iraque
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Irã
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Islândia
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Itália
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jérsei
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaica
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordânia
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japão
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Quênia
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Quirguistão
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Camboja
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Comores
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: São Cristóvão e Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Coreia do Norte
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Coreia do Sul
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Kosovo
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Ilhas Cayman
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Cazaquistão
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Líbano
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Santa Lúcia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Libéria
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesoto
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Lituânia
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxemburgo
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Letônia
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Líbia
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Marrocos
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Mônaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldávia
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: São Martinho (França)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagáscar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Ilhas Marshall
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedônia
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Mianmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongólia
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macau
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Ilhas Marianas do Norte
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinica
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritânia
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Monserrate
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Maurícia
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldivas
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malaui
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: México
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malásia
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Moçambique
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namíbia
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nova Caledónia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Níger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Ilha Norfolk
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigéria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nicarágua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Holanda
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Noruega
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nova Zelândia
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Omã
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panamá
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Polinésia Francesa
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua-Nova Guiné
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipinas
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Paquistão
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polônia
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint-Pierre e Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Ilhas Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Porto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestina
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguai
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunião
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Romênia
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Sérvia
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Rússia
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Arábia Saudita
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Ilhas Salomão
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seicheles
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudão
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Suécia
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapura
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Santa Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Eslovênia
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard e Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Eslováquia
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Serra Leoa
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somália
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Suriname
       official_name: !!null 
+      nationality: !!null 
     ss:
       common_name: !!null 
       name: Sudão do Sul
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: São Tomé e Príncipe
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sx:
       common_name: !!null 
       name: São Martinho (Países Baixos)
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Síria
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Suazilândia
       official_name: !!null 
+      nationality: !!null 
     ta:
       common_name: !!null 
       name: Tristão da Cunha
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Turks e Caicos
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chade
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Terras Austrais e Antárticas Francesas
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Tailândia
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tajiquistão
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timor-Leste
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turquemenistão
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunísia
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turquia
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad e Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Taiwan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzânia
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ucrânia
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Ilhas Menores Distantes dos Estados Unidos
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Estados Unidos
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguai
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbequistão
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Cidade do Vaticano
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: São Vicente e Granadinas
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Ilhas Virgens Britânicas
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Ilhas Virgens Americanas
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnã
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis e Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Iémen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Maiote
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: África do Sul
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zâmbia
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabue
       official_name: !!null 
+      nationality: !!null 

--- a/locale/ru/world.yml
+++ b/locale/ru/world.yml
@@ -5,1011 +5,1264 @@ ru:
       common_name: !!null 
       name: Остров Вознесения
       official_name: !!null 
+      nationality: !!null 
     ad:
       common_name: !!null 
       name: Андорра
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Объединенные Арабские Эмираты
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Афганистан
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Антигуа и Барбуда
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Ангилья
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Албания
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Армения
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Нидерландские Антильские острова
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Ангола
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Антарктида
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Аргентина
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Американское Самоа
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Австрия
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Австралия
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Аруба
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Аландские острова
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Азербайджан
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Босния и Герцеговина
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Барбадос
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Бангладеш
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Бельгия
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Буркина Фасо
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Болгария
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Бахрейн
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Бурунди
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Бенин
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Сен-Бартельми
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Бермудские острова
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Бруней-Даруссалам
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Боливия
       official_name: !!null 
+      nationality: !!null 
     bq:
       common_name: !!null 
       name: Бона́йре, Синт-Эста́тиус и Са́ба
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Бразилия
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Багамские острова
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Бутан
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Остров Буве
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Ботсвана
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Беларусь
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Белиз
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Канада
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Кокосовы острова
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Конго, Демократическая Республика
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Центрально-Африканская республика
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Конго
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Швейцария
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Кот-д’Ивуар
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Острова Кука
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Чили
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Камерун
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: Китай
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Колумбия
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Коста-Рика
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Куба
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Кабо-Верде
       official_name: !!null 
+      nationality: !!null 
     cw:
       common_name: !!null 
       name: Кюрасао
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Острова Рождества
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Кипр
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Чешская республика
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Германия
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Джибути
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Дания
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Доминика
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Доминиканская Республика
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Алжир
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Эквадор
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Эстония
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Египет
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Западная Сахара
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Эритрея
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Испания
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Эфиопия
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Финляндия
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Фиджи
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Фолклендские (Мальвинские) острова
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Микронезия, Федеративные Штаты
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Фарерские острова
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Франция
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Габон
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Великобритания
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Гренада
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Грузия
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Французская Гвиана
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Гернси
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Гана
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Гибралтар
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Гренландия
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Гамбия
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Гвинея
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Гваделупа
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Экваториальная Гвинея
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Греция
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Южная Джорджия и Южные Сандвичевы острова
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Гватемала
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Гуам
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Гвинея-Бисау
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Гайана
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Гонконг
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Остров Херд и острова Макдональд
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Гондурас
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Хорватия
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Гаити
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Венгрия
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Индонезия
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Ирландия
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Израиль
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Остров Мэн
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Индия
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Британские территории в Индийском океане
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Ирак
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Иран, Исламская Республика
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Исландия
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Италия
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Джерси
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Ямайка
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Иордания
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Япония
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Кения
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Кыргызстан
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Камбоджа
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Кирибати
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Коморские острова
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Сент-Китс и Невис
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Корейская Народно-Демократическая Республика
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Республика Корея
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Косово
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Кувейт
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Каймановы острова
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Казахстан
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Лаосская Народно-Демократическая Республика
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Ливан
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Сент-Люсия
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Лихтенштейн
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Шри Ланка
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Либерия
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Лесото
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Литва
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Люксембург
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Латвия
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Ливия
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Марокко
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Монако
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Молдова
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Черногория
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Сен-Мартен (Французская часть)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Мадагаскар
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Маршалловы острова
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Македония, Республика
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Мали
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Мьянма
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Монголия
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Макао
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Северные Марианские острова
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Мартиника
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Мавритания
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Монтсеррат
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Мальта
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Маврикий
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Мальдивы
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Малави
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Мексика
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Малайзия
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Мозамбик
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Намибия
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Новая Каледония
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Нигер
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Остров Норфолк
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Нигерия
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Никарагуа
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Нидерланды
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Норвегия
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Непал
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Науру
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Ниуэ
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Новая Зеландия
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Оман
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Панама
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Перу
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Французская Полинезия
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Папуа-Новая Гвинея
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Филиппины
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Пакистан
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Польша
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Сен-Пьер и Микелон
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Питкэрн
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Пуэрто-Рико
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Палестинские территории
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Португалия
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Палау
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Парагвай
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Катар
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Реюньон
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Румыния
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Сербия
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Российская Федерация
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Руанда
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Саудовская Аравия
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Соломоновы Острова
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Сейшельские острова
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Судан
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Швеция
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Сингапур
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Остров Святой Елены
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Словения
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Шпицберген и Ян-Майен
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Словакия
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Сьерра-Леоне
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: Сан-Марино
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Сенегал
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Сомали
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Суринам
       official_name: !!null 
+      nationality: !!null 
     ss:
       common_name: !!null 
       name: Южный Судан, Республика
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Сан-Томе и Принсипи
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: Сальвадор
       official_name: !!null 
+      nationality: !!null 
     sx:
       common_name: !!null 
       name: Синт-Маартен (Голландская часть)
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Сирия
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Свазиленд
       official_name: !!null 
+      nationality: !!null 
     ta:
       common_name: !!null 
       name: Тристан-да-Кунья
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Острова Теркс и Кайкос
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Чад
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Французские Южные территории
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Того
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Таиланд
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Таджикистан
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Токелау
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Тимор-Лешти
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Туркменистан
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Тунис
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Тонга
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Турция
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Тринидад и Тобаго
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Тувалу
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Тайвань
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Танзания, Объединенная Республика
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Украина
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Уганда
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Внешние малые острова (США)
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Соединенные Штаты Америки
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Уругвай
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Узбекистан
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Святой Престол (Государство-город Ватикан)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Сент-Винсент и Гренадины
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Венесуэла
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Виргинские острова, Британские
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Виргинские острова, США
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Вьетнам
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Вануату
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Уоллис и Футуна
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Самоа
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Йемен
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Майотта
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: ЮАР
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Замбия
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Зимбабве
       official_name: !!null 
+      nationality: !!null 

--- a/locale/sk/world.yml
+++ b/locale/sk/world.yml
@@ -5,979 +5,1224 @@ sk:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Spojené arabské emiráty
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afganistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua a Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Albánsko
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Arménsko
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Holandské Antily
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktída
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Argentína
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Americká Samoa
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Rakúsko
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Austrália
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     ax:
       common_name: !!null 
       name: Alandské ostrovy
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbajdžan
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosna a Hercegovina
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladéš
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belgicko
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulharsko
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahrajn
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bl:
       common_name: !!null 
       name: Saint Barthelemy
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermudy
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunejsko-darussalamský štát
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolívia
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brazília
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamy
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhután
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Bouvet Island
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Bielorusko
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Kokosové ostrovy (Keeling) ostrovy
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongo, demokratická republika
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Stredoafrická republika
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Kongo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: Švajčiarsko
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Pobrežie Slonoviny
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cookove ostrovy
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Čile
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolumbia
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Kuba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Cape Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Vianočný ostrov
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Cyprus
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Česká republika
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Nemecko
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Džibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Dánsko
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominikánska republika
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Alžírsko
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estónsko
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Egypt
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Západná Sahara
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: Španielsko
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiópia
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Fínsko
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fidži
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falklandské ostrovy (Malvíny)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronézia, Federálne štáty
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Francúzsko
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Veľká Británia
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Gruzínsko
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Francúzska Guyana
       official_name: !!null 
+      nationality: !!null 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltár
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grónsko
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Rovníková Guinea
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Grécko
       official_name: !!null 
+      nationality: !!null 
     gs:
       common_name: !!null 
       name: Južná Georgia a Južné Sandwichove ostrovy
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heardov ostrov a McDonaldove ostrovy
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Chorvátsko
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Maďarsko
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Indonézia
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: Írsko
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: Izrael
       official_name: !!null 
+      nationality: !!null 
     im:
       common_name: !!null 
       name: Isle of Man
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: India
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: Britské indickooceánske územie
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: Iránska islamská republika
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: Island
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: Taliansko
       official_name: !!null 
+      nationality: !!null 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamajka
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Jordánsko
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japonsko
       official_name: !!null 
+      nationality: !!null 
     jv:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Keňa
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kirgizsko
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kambodža
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komory
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: Svätý Krištof a Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Kórea, ľudovodemokratická republika v
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Kórejská republika
       official_name: !!null 
+      nationality: !!null 
     kv:
       common_name: !!null 
       name: Kosovo
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuvajt
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Kajmanské ostrovy
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazachstan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laoskej ľudovo demokratickej republiky
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Saint Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Lichtenštajnsko
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Srí Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Libéria
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litva
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Luxembursko
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Lotyšsko
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Líbya
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Maroko
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldavská republika
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Čierna Hora
       official_name: !!null 
+      nationality: !!null 
     mf:
       common_name: !!null 
       name: Saint Martin (francúzska časť)
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marshallove ostrovy
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Macedónsko, Bývalá juhoslovanská republika
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Mjanmarsko
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Mongolsko
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Severné Mariány
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinik
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Mauritánia
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Maurícius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maledivy
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Mexiko
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malajsie
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambik
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namíbia
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Nová Kaledónia
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nigéria
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nikaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Holandsko
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Nórsko
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepál
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Nový Zéland
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Omán
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Francúzska Polynézia
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua Nová Guinea
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipíny
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pákistán
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Poľsko
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: Saint Pierre a Miquelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: !!null 
     ps:
       common_name: !!null 
       name: Palestínske územia, okupované
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portugalsko
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguaj
       official_name: !!null 
+      nationality: !!null 
     pre:
       common_name: !!null 
       name: Faerské ostrovy
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Katar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunion
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Rumunsko
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Srbsko
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Ruská federácia
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Rwanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Saudská Arábia
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Šalamúnove ostrovy
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seychely
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudán
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: Švédsko
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: Svätá Helena
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovinsko
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Špicbergy a Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovensko
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Maríno
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somálsko
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Surinam
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Svätý Tomáš a Princov
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Sýrska arabská republika
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Svazijsko
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Ostrovy Turks a Caicos
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Chad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Francúzske južné územia
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Thajsko
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tadžikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Východný Timor
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Turkménsko
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunisko
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Turecko
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad a Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Tchaj-wan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzánia, zjednotená republika
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukrajina
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: Spojené štáty Menšie odľahlé ostrovy
       official_name: !!null 
+      nationality: !!null 
     usa:
       common_name: !!null 
       name: Spojené štáty americké
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguaj
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Uzbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Svätá stolica (Vatikánsky mestský štát)
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: Svätý Vincent a Grenadíny
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Britské Panenské ostrovy
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Americké Panenské ostrovy
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Viet Nam
       official_name: !!null 
+      nationality: !!null 
     vo:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Wallis a Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Jihoafrická republika
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambia
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: !!null 
     Čr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: !!null 

--- a/locale/sv/world.yml
+++ b/locale/sv/world.yml
@@ -5,1035 +5,1294 @@ sv:
       common_name: !!null 
       name: Ascension
       official_name: !!null 
+      nationality: 
     ad:
       common_name: !!null 
       name: Andorra
       official_name: !!null 
+      nationality: 
     ae:
       common_name: !!null 
       name: Förenade Arabemiraten
       official_name: !!null 
+      nationality: 
     af:
       common_name: !!null 
       name: Afghanistan
       official_name: !!null 
+      nationality: 
     ag:
       common_name: !!null 
       name: Antigua och Barbuda
       official_name: !!null 
+      nationality: 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: 
     al:
       common_name: !!null 
       name: Albanien
       official_name: !!null 
+      nationality: 
     am:
       common_name: !!null 
       name: Armenien
       official_name: !!null 
+      nationality: 
     an:
       common_name: !!null 
       name: Nederländska Antillerna
       official_name: !!null 
+      nationality: 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: 
     aq:
       common_name: !!null 
       name: Antarktis
       official_name: !!null 
+      nationality: 
     ar:
       common_name: !!null 
       name: Argentina
       official_name: !!null 
+      nationality: 
     as:
       common_name: !!null 
       name: Amerikanska Samoa
       official_name: !!null 
+      nationality: 
     at:
       common_name: !!null 
       name: Österrike
       official_name: !!null 
+      nationality: 
     au:
       common_name: !!null 
       name: Australien
       official_name: !!null 
+      nationality: 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: 
     ax:
       common_name: !!null 
       name: Åland
       official_name: !!null 
+      nationality: 
     az:
       common_name: !!null 
       name: Azerbajdzjan
       official_name: !!null 
+      nationality: 
     ba:
       common_name: !!null 
       name: Bosnien och Hercegovina
       official_name: !!null 
+      nationality: 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: 
     bd:
       common_name: !!null 
       name: Bangladesh
       official_name: !!null 
+      nationality: 
     be:
       common_name: !!null 
       name: Belgien
       official_name: !!null 
+      nationality: 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: 
     bg:
       common_name: !!null 
       name: Bulgarien
       official_name: !!null 
+      nationality: 
     bh:
       common_name: !!null 
       name: Bahrain
       official_name: !!null 
+      nationality: 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: 
     bl:
       common_name: !!null 
       name: S:t Barthélemy
       official_name: !!null 
+      nationality: 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: 
     bo:
       common_name: !!null 
       name: Bolivia
       official_name: !!null 
+      nationality: 
     bq:
       common_name: !!null 
       name: BQ
       official_name: !!null 
+      nationality: 
     br:
       common_name: !!null 
       name: Brasilien
       official_name: !!null 
+      nationality: 
     bs:
       common_name: !!null 
       name: Bahamas
       official_name: !!null 
+      nationality: 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: 
     bv:
       common_name: !!null 
       name: Bouvetön
       official_name: !!null 
+      nationality: 
     bw:
       common_name: !!null 
       name: Botswana
       official_name: !!null 
+      nationality: 
     by:
       common_name: !!null 
       name: Vitryssland
       official_name: !!null 
+      nationality: 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: 
     cc:
       common_name: !!null 
       name: Kokosöarna
       official_name: !!null 
+      nationality: 
     cd:
       common_name: !!null 
       name: Kongo-Kinshasa
       official_name: !!null 
+      nationality: 
     cf:
       common_name: !!null 
       name: Centralafrikanska republiken
       official_name: !!null 
+      nationality: 
     cg:
       common_name: !!null 
       name: Kongo-Brazzaville
       official_name: !!null 
+      nationality: 
     ch:
       common_name: !!null 
       name: Schweiz
       official_name: !!null 
+      nationality: 
     ci:
       common_name: !!null 
       name: Elfenbenskusten
       official_name: !!null 
+      nationality: 
     ck:
       common_name: !!null 
       name: Cooköarna
       official_name: !!null 
+      nationality: 
     cl:
       common_name: !!null 
       name: Chile
       official_name: !!null 
+      nationality: 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: 
     cn:
       common_name: !!null 
       name: Kina
       official_name: !!null 
+      nationality: 
     co:
       common_name: !!null 
       name: Colombia
       official_name: !!null 
+      nationality: 
     cp:
       common_name: !!null 
       name: Clippertonön
       official_name: !!null 
+      nationality: 
     cr:
       common_name: !!null 
       name: Costa Rica
       official_name: !!null 
+      nationality: 
     cs:
       common_name: !!null 
       name: Serbien och Montenegro
       official_name: !!null 
+      nationality: 
     cu:
       common_name: !!null 
       name: Kuba
       official_name: !!null 
+      nationality: 
     cv:
       common_name: !!null 
       name: Kap Verde
       official_name: !!null 
+      nationality: 
     cw:
       common_name: !!null 
       name: CW
       official_name: !!null 
+      nationality: 
     cx:
       common_name: !!null 
       name: Julön
       official_name: !!null 
+      nationality: 
     cy:
       common_name: !!null 
       name: Cypern
       official_name: !!null 
+      nationality: 
     cz:
       common_name: !!null 
       name: Tjeckien
       official_name: !!null 
+      nationality: 
     de:
       common_name: !!null 
       name: Tyskland
       official_name: !!null 
+      nationality: 
     dg:
       common_name: !!null 
       name: Diego Garcia
       official_name: !!null 
+      nationality: 
     dj:
       common_name: !!null 
       name: Djibouti
       official_name: !!null 
+      nationality: 
     dk:
       common_name: !!null 
       name: Danmark
       official_name: !!null 
+      nationality: 
     dm:
       common_name: !!null 
       name: Dominica
       official_name: !!null 
+      nationality: 
     do:
       common_name: !!null 
       name: Dominikanska republiken
       official_name: !!null 
+      nationality: 
     dz:
       common_name: !!null 
       name: Algeriet
       official_name: !!null 
+      nationality: 
     ea:
       common_name: !!null 
       name: Ceuta och Melilla
       official_name: !!null 
+      nationality: 
     ec:
       common_name: !!null 
       name: Ecuador
       official_name: !!null 
+      nationality: 
     ee:
       common_name: !!null 
       name: Estland
       official_name: !!null 
+      nationality: 
     eg:
       common_name: !!null 
       name: Egypten
       official_name: !!null 
+      nationality: 
     eh:
       common_name: !!null 
       name: Västsahara
       official_name: !!null 
+      nationality: 
     er:
       common_name: !!null 
       name: Eritrea
       official_name: !!null 
+      nationality: 
     es:
       common_name: !!null 
       name: Spanien
       official_name: !!null 
+      nationality: 
     et:
       common_name: !!null 
       name: Etiopien
       official_name: !!null 
+      nationality: 
     eu:
       common_name: !!null 
       name: Europeiska unionen
       official_name: !!null 
+      nationality: 
     fi:
       common_name: !!null 
       name: Finland
       official_name: !!null 
+      nationality: 
     fj:
       common_name: !!null 
       name: Fiji
       official_name: !!null 
+      nationality: 
     fk:
       common_name: !!null 
       name: Falklandsöarna
       official_name: !!null 
+      nationality: 
     fm:
       common_name: !!null 
       name: Mikronesien
       official_name: !!null 
+      nationality: 
     fo:
       common_name: !!null 
       name: Färöarna
       official_name: !!null 
+      nationality: 
     fr:
       common_name: !!null 
       name: Frankrike
       official_name: !!null 
+      nationality: 
     fx:
       common_name: !!null 
       name: Europeiska Frankrike
       official_name: !!null 
+      nationality: 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: 
     gb:
       common_name: !!null 
       name: Storbritannien
       official_name: !!null 
+      nationality: 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: 
     ge:
       common_name: !!null 
       name: Georgien
       official_name: !!null 
+      nationality: 
     gf:
       common_name: !!null 
       name: Franska Guyana
       official_name: !!null 
+      nationality: 
     gg:
       common_name: !!null 
       name: Guernsey
       official_name: !!null 
+      nationality: 
     gh:
       common_name: !!null 
       name: Ghana
       official_name: !!null 
+      nationality: 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: 
     gl:
       common_name: !!null 
       name: Grönland
       official_name: !!null 
+      nationality: 
     gm:
       common_name: !!null 
       name: Gambia
       official_name: !!null 
+      nationality: 
     gn:
       common_name: !!null 
       name: Guinea
       official_name: !!null 
+      nationality: 
     gp:
       common_name: !!null 
       name: Guadeloupe
       official_name: !!null 
+      nationality: 
     gq:
       common_name: !!null 
       name: Ekvatorialguinea
       official_name: !!null 
+      nationality: 
     gr:
       common_name: !!null 
       name: Grekland
       official_name: !!null 
+      nationality: 
     gs:
       common_name: !!null 
       name: Sydgeorgien och Sydsandwichöarna
       official_name: !!null 
+      nationality: 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: 
     gw:
       common_name: !!null 
       name: Guinea-Bissau
       official_name: !!null 
+      nationality: 
     gy:
       common_name: !!null 
       name: Guyana
       official_name: !!null 
+      nationality: 
     hk:
       common_name: !!null 
       name: Hongkong
       official_name: !!null 
+      nationality: 
     hm:
       common_name: !!null 
       name: Heard- och McDonaldöarna
       official_name: !!null 
+      nationality: 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: 
     hr:
       common_name: !!null 
       name: Kroatien
       official_name: !!null 
+      nationality: 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: 
     hu:
       common_name: !!null 
       name: Ungern
       official_name: !!null 
+      nationality: 
     ic:
       common_name: !!null 
       name: Kanarieöarna
       official_name: !!null 
+      nationality: 
     id:
       common_name: !!null 
       name: Indonesien
       official_name: !!null 
+      nationality: 
     ie:
       common_name: !!null 
       name: Irland
       official_name: !!null 
+      nationality: 
     il:
       common_name: !!null 
       name: Israel
       official_name: !!null 
+      nationality: 
     im:
       common_name: !!null 
       name: Isle of Man
       official_name: !!null 
+      nationality: 
     in:
       common_name: !!null 
       name: Indien
       official_name: !!null 
+      nationality: 
     io:
       common_name: !!null 
       name: Brittiska Indiska oceanöarna
       official_name: !!null 
+      nationality: 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: 
     ir:
       common_name: !!null 
       name: Iran
       official_name: !!null 
+      nationality: 
     is:
       common_name: !!null 
       name: Island
       official_name: !!null 
+      nationality: 
     it:
       common_name: !!null 
       name: Italien
       official_name: !!null 
+      nationality: 
     je:
       common_name: !!null 
       name: Jersey
       official_name: !!null 
+      nationality: 
     jm:
       common_name: !!null 
       name: Jamaica
       official_name: !!null 
+      nationality: 
     jo:
       common_name: !!null 
       name: Jordanien
       official_name: !!null 
+      nationality: 
     jp:
       common_name: !!null 
       name: Japan
       official_name: !!null 
+      nationality: 
     ke:
       common_name: !!null 
       name: Kenya
       official_name: !!null 
+      nationality: 
     kg:
       common_name: !!null 
       name: Kirgizistan
       official_name: !!null 
+      nationality: 
     kh:
       common_name: !!null 
       name: Kambodja
       official_name: !!null 
+      nationality: 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: 
     km:
       common_name: !!null 
       name: Komorerna
       official_name: !!null 
+      nationality: 
     kn:
       common_name: !!null 
       name: S:t Kitts och Nevis
       official_name: !!null 
+      nationality: 
     kp:
       common_name: !!null 
       name: Nordkorea
       official_name: !!null 
+      nationality: 
     kr:
       common_name: !!null 
       name: Sydkorea
       official_name: !!null 
+      nationality: 
     kw:
       common_name: !!null 
       name: Kuwait
       official_name: !!null 
+      nationality: 
     ky:
       common_name: !!null 
       name: Caymanöarna
       official_name: !!null 
+      nationality: 
     kz:
       common_name: !!null 
       name: Kazakstan
       official_name: !!null 
+      nationality: 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: 
     lb:
       common_name: !!null 
       name: Libanon
       official_name: !!null 
+      nationality: 
     lc:
       common_name: !!null 
       name: S:t Lucia
       official_name: !!null 
+      nationality: 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: 
     lr:
       common_name: !!null 
       name: Liberia
       official_name: !!null 
+      nationality: 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: 
     lt:
       common_name: !!null 
       name: Litauen
       official_name: !!null 
+      nationality: 
     lu:
       common_name: !!null 
       name: Luxemburg
       official_name: !!null 
+      nationality: 
     lv:
       common_name: !!null 
       name: Lettland
       official_name: !!null 
+      nationality: 
     ly:
       common_name: !!null 
       name: Libyen
       official_name: !!null 
+      nationality: 
     ma:
       common_name: !!null 
       name: Marocko
       official_name: !!null 
+      nationality: 
     mc:
       common_name: !!null 
       name: Monaco
       official_name: !!null 
+      nationality: 
     md:
       common_name: !!null 
       name: Moldavien
       official_name: !!null 
+      nationality: 
     me:
       common_name: !!null 
       name: Montenegro
       official_name: !!null 
+      nationality: 
     mf:
       common_name: !!null 
       name: S:t Martin
       official_name: !!null 
+      nationality: 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: 
     mh:
       common_name: !!null 
       name: Marshallöarna
       official_name: !!null 
+      nationality: 
     mk:
       common_name: !!null 
       name: Makedonien
       official_name: !!null 
+      nationality: 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: 
     mn:
       common_name: !!null 
       name: Mongoliet
       official_name: !!null 
+      nationality: 
     mo:
       common_name: !!null 
       name: Macao
       official_name: !!null 
+      nationality: 
     mp:
       common_name: !!null 
       name: Nordmarianerna
       official_name: !!null 
+      nationality: 
     mq:
       common_name: !!null 
       name: Martinique
       official_name: !!null 
+      nationality: 
     mr:
       common_name: !!null 
       name: Mauretanien
       official_name: !!null 
+      nationality: 
     ms:
       common_name: !!null 
       name: Montserrat
       official_name: !!null 
+      nationality: 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: 
     mv:
       common_name: !!null 
       name: Maldiverna
       official_name: !!null 
+      nationality: 
     mw:
       common_name: !!null 
       name: Malawi
       official_name: !!null 
+      nationality: 
     mx:
       common_name: !!null 
       name: Mexiko
       official_name: !!null 
+      nationality: 
     my:
       common_name: !!null 
       name: Malaysia
       official_name: !!null 
+      nationality: 
     mz:
       common_name: !!null 
       name: Moçambique
       official_name: !!null 
+      nationality: 
     na:
       common_name: !!null 
       name: Namibia
       official_name: !!null 
+      nationality: 
     nc:
       common_name: !!null 
       name: Nya Kaledonien
       official_name: !!null 
+      nationality: 
     ne:
       common_name: !!null 
       name: Niger
       official_name: !!null 
+      nationality: 
     nf:
       common_name: !!null 
       name: Norfolkön
       official_name: !!null 
+      nationality: 
     ng:
       common_name: !!null 
       name: Nigeria
       official_name: !!null 
+      nationality: 
     ni:
       common_name: !!null 
       name: Nicaragua
       official_name: !!null 
+      nationality: 
     nl:
       common_name: !!null 
       name: Nederländerna
       official_name: !!null 
+      nationality: 
     'no':
       common_name: !!null 
       name: Norge
       official_name: !!null 
+      nationality: 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: 
     nz:
       common_name: !!null 
       name: Nya Zeeland
       official_name: !!null 
+      nationality: 
     om:
       common_name: !!null 
       name: Oman
       official_name: !!null 
+      nationality: 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: 
     pf:
       common_name: !!null 
       name: Franska Polynesien
       official_name: !!null 
+      nationality: 
     pg:
       common_name: !!null 
       name: Papua Nya Guinea
       official_name: !!null 
+      nationality: 
     ph:
       common_name: !!null 
       name: Filippinerna
       official_name: !!null 
+      nationality: 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: 
     pl:
       common_name: !!null 
       name: Polen
       official_name: !!null 
+      nationality: 
     pm:
       common_name: !!null 
       name: S:t Pierre och Miquelon
       official_name: !!null 
+      nationality: 
     pn:
       common_name: !!null 
       name: Pitcairn
       official_name: !!null 
+      nationality: 
     pr:
       common_name: !!null 
       name: Puerto Rico
       official_name: !!null 
+      nationality: 
     ps:
       common_name: !!null 
       name: Palestinska territoriet
       official_name: !!null 
+      nationality: 
     pt:
       common_name: !!null 
       name: Portugal
       official_name: !!null 
+      nationality: 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: 
     qa:
       common_name: !!null 
       name: Qatar
       official_name: !!null 
+      nationality: 
     qo:
       common_name: !!null 
       name: Yttre öar i Oceanien
       official_name: !!null 
+      nationality: 
     re:
       common_name: !!null 
       name: Réunion
       official_name: !!null 
+      nationality: 
     ro:
       common_name: !!null 
       name: Rumänien
       official_name: !!null 
+      nationality: 
     rs:
       common_name: !!null 
       name: Serbien
       official_name: !!null 
+      nationality: 
     ru:
       common_name: !!null 
       name: Ryssland
       official_name: !!null 
+      nationality: 
     rw:
       common_name: !!null 
       name: Rwanda
       official_name: !!null 
+      nationality: 
     sa:
       common_name: !!null 
       name: Saudiarabien
       official_name: !!null 
+      nationality: 
     sb:
       common_name: !!null 
       name: Salomonöarna
       official_name: !!null 
+      nationality: 
     sc:
       common_name: !!null 
       name: Seychellerna
       official_name: !!null 
+      nationality: 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: !!null 
+      nationality: 
     se:
       common_name: !!null 
       name: Sverige
       official_name: !!null 
+      nationality: 
     sg:
       common_name: !!null 
       name: Singapore
       official_name: !!null 
+      nationality: 
     sh:
       common_name: !!null 
       name: S:t Helena
       official_name: !!null 
+      nationality: 
     si:
       common_name: !!null 
       name: Slovenien
       official_name: !!null 
+      nationality: 
     sj:
       common_name: !!null 
       name: Svalbard och Jan Mayen
       official_name: !!null 
+      nationality: 
     sk:
       common_name: !!null 
       name: Slovakien
       official_name: !!null 
+      nationality: 
     sl:
       common_name: !!null 
       name: Sierra Leone
       official_name: !!null 
+      nationality: 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: 
     so:
       common_name: !!null 
       name: Somalia
       official_name: !!null 
+      nationality: 
     sr:
       common_name: !!null 
       name: Surinam
       official_name: !!null 
+      nationality: 
     st:
       common_name: !!null 
       name: São Tomé och Príncipe
       official_name: !!null 
+      nationality: 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: 
     sx:
       common_name: !!null 
       name: SX
       official_name: !!null 
+      nationality: 
     sy:
       common_name: !!null 
       name: Syrien
       official_name: !!null 
+      nationality: 
     sz:
       common_name: !!null 
       name: Swaziland
       official_name: !!null 
+      nationality: 
     ta:
       common_name: !!null 
       name: Tristan da Cunha
       official_name: !!null 
+      nationality: 
     tc:
       common_name: !!null 
       name: Turks- och Caicosöarna
       official_name: !!null 
+      nationality: 
     td:
       common_name: !!null 
       name: Tchad
       official_name: !!null 
+      nationality: 
     tf:
       common_name: !!null 
       name: Franska Sydterritorierna
       official_name: !!null 
+      nationality: 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: 
     th:
       common_name: !!null 
       name: Thailand
       official_name: !!null 
+      nationality: 
     tj:
       common_name: !!null 
       name: Tadzjikistan
       official_name: !!null 
+      nationality: 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: 
     tl:
       common_name: !!null 
       name: Östtimor
       official_name: !!null 
+      nationality: 
     tm:
       common_name: !!null 
       name: Turkmenistan
       official_name: !!null 
+      nationality: 
     tn:
       common_name: !!null 
       name: Tunisien
       official_name: !!null 
+      nationality: 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: 
     tr:
       common_name: !!null 
       name: Turkiet
       official_name: !!null 
+      nationality: 
     tt:
       common_name: !!null 
       name: Trinidad och Tobago
       official_name: !!null 
+      nationality: 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: 
     tw:
       common_name: !!null 
       name: Taiwan
       official_name: !!null 
+      nationality: 
     tz:
       common_name: !!null 
       name: Tanzania
       official_name: !!null 
+      nationality: 
     ua:
       common_name: !!null 
       name: Ukraina
       official_name: !!null 
+      nationality: 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: 
     um:
       common_name: !!null 
       name: USA:s yttre öar
       official_name: !!null 
+      nationality: 
     us:
       common_name: !!null 
       name: USA
       official_name: !!null 
+      nationality: 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: 
     uz:
       common_name: !!null 
       name: Uzbekistan
       official_name: !!null 
+      nationality: 
     va:
       common_name: !!null 
       name: Vatikanstaten
       official_name: !!null 
+      nationality: 
     vc:
       common_name: !!null 
       name: S:t Vincent och Grenadinerna
       official_name: !!null 
+      nationality: 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: 
     vg:
       common_name: !!null 
       name: Brittiska Jungfruöarna
       official_name: !!null 
+      nationality: 
     vi:
       common_name: !!null 
       name: Amerikanska Jungfruöarna
       official_name: !!null 
+      nationality: 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: 
     wf:
       common_name: !!null 
       name: Wallis- och Futunaöarna
       official_name: !!null 
+      nationality: 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: 
     ye:
       common_name: !!null 
       name: Jemen
       official_name: !!null 
+      nationality: 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: 
     za:
       common_name: !!null 
       name: Sydafrika
       official_name: !!null 
+      nationality: 
     zm:
       common_name: !!null 
       name: Zambia
       official_name: !!null 
+      nationality: 
     zw:
       common_name: !!null 
       name: Zimbabwe
       official_name: !!null 
+      nationality: 

--- a/locale/tr/world.yml
+++ b/locale/tr/world.yml
@@ -5,951 +5,1189 @@ tr:
       common_name: !!null 
       name: Andora
       official_name: !!null 
+      nationality: !!null 
     ae:
       common_name: !!null 
       name: Birleşik Arap Emirlikleri
       official_name: !!null 
+      nationality: !!null 
     af:
       common_name: !!null 
       name: Afganistan
       official_name: !!null 
+      nationality: !!null 
     ag:
       common_name: !!null 
       name: Antigua ve Barbuda
       official_name: !!null 
+      nationality: !!null 
     ai:
       common_name: !!null 
       name: Anguilla
       official_name: !!null 
+      nationality: !!null 
     al:
       common_name: !!null 
       name: Arnavutluk
       official_name: !!null 
+      nationality: !!null 
     am:
       common_name: !!null 
       name: Ermenistan
       official_name: !!null 
+      nationality: !!null 
     an:
       common_name: !!null 
       name: Hollanda Antilleri
       official_name: !!null 
+      nationality: !!null 
     ao:
       common_name: !!null 
       name: Angola
       official_name: !!null 
+      nationality: !!null 
     aq:
       common_name: !!null 
       name: Antarktika
       official_name: !!null 
+      nationality: !!null 
     ar:
       common_name: !!null 
       name: Arjantin
       official_name: !!null 
+      nationality: !!null 
     as:
       common_name: !!null 
       name: Amerikan Samoası
       official_name: !!null 
+      nationality: !!null 
     at:
       common_name: !!null 
       name: Avusturya
       official_name: !!null 
+      nationality: !!null 
     au:
       common_name: !!null 
       name: Avustralya
       official_name: !!null 
+      nationality: !!null 
     aw:
       common_name: !!null 
       name: Aruba
       official_name: !!null 
+      nationality: !!null 
     az:
       common_name: !!null 
       name: Azerbaycan
       official_name: !!null 
+      nationality: !!null 
     ba:
       common_name: !!null 
       name: Bosna Hersek
       official_name: !!null 
+      nationality: !!null 
     bb:
       common_name: !!null 
       name: Barbados
       official_name: !!null 
+      nationality: !!null 
     bd:
       common_name: !!null 
       name: Bangladeş
       official_name: !!null 
+      nationality: !!null 
     be:
       common_name: !!null 
       name: Belçika
       official_name: !!null 
+      nationality: !!null 
     bf:
       common_name: !!null 
       name: Burkina Faso
       official_name: !!null 
+      nationality: !!null 
     bg:
       common_name: !!null 
       name: Bulgaristan
       official_name: !!null 
+      nationality: !!null 
     bh:
       common_name: !!null 
       name: Bahreyn
       official_name: !!null 
+      nationality: !!null 
     bi:
       common_name: !!null 
       name: Burundi
       official_name: !!null 
+      nationality: !!null 
     bj:
       common_name: !!null 
       name: Benin
       official_name: !!null 
+      nationality: !!null 
     bm:
       common_name: !!null 
       name: Bermuda
       official_name: !!null 
+      nationality: !!null 
     bn:
       common_name: !!null 
       name: Brunei
       official_name: !!null 
+      nationality: !!null 
     bo:
       common_name: !!null 
       name: Bolivya
       official_name: !!null 
+      nationality: !!null 
     br:
       common_name: !!null 
       name: Brezilya
       official_name: !!null 
+      nationality: !!null 
     bs:
       common_name: !!null 
       name: Bahamalar
       official_name: !!null 
+      nationality: !!null 
     bt:
       common_name: !!null 
       name: Bhutan
       official_name: !!null 
+      nationality: !!null 
     bv:
       common_name: !!null 
       name: Buvet Adası
       official_name: !!null 
+      nationality: !!null 
     bw:
       common_name: !!null 
       name: Botsvana
       official_name: !!null 
+      nationality: !!null 
     by:
       common_name: !!null 
       name: Belarus
       official_name: !!null 
+      nationality: !!null 
     bz:
       common_name: !!null 
       name: Belize
       official_name: !!null 
+      nationality: !!null 
     ca:
       common_name: !!null 
       name: Kanada
       official_name: !!null 
+      nationality: !!null 
     cc:
       common_name: !!null 
       name: Cocos (Keeling) Adaları
       official_name: !!null 
+      nationality: !!null 
     cd:
       common_name: !!null 
       name: Kongo Demokratik Cumhuriyeti
       official_name: !!null 
+      nationality: !!null 
     cf:
       common_name: !!null 
       name: Orta Afrika Cumhuriyeti
       official_name: !!null 
+      nationality: !!null 
     cg:
       common_name: !!null 
       name: Kongo
       official_name: !!null 
+      nationality: !!null 
     ch:
       common_name: !!null 
       name: İsviçre
       official_name: !!null 
+      nationality: !!null 
     ci:
       common_name: !!null 
       name: Fildişi Sahili
       official_name: !!null 
+      nationality: !!null 
     ck:
       common_name: !!null 
       name: Cook Adaları
       official_name: !!null 
+      nationality: !!null 
     cl:
       common_name: !!null 
       name: Şili
       official_name: !!null 
+      nationality: !!null 
     cm:
       common_name: !!null 
       name: Kamerun
       official_name: !!null 
+      nationality: !!null 
     cn:
       common_name: !!null 
       name: Çin
       official_name: !!null 
+      nationality: !!null 
     co:
       common_name: !!null 
       name: Kolombiya
       official_name: !!null 
+      nationality: !!null 
     cr:
       common_name: !!null 
       name: Kosta Rika
       official_name: !!null 
+      nationality: !!null 
     cu:
       common_name: !!null 
       name: Küba
       official_name: !!null 
+      nationality: !!null 
     cv:
       common_name: !!null 
       name: Cape Verde
       official_name: !!null 
+      nationality: !!null 
     cx:
       common_name: !!null 
       name: Christmas Adası
       official_name: !!null 
+      nationality: !!null 
     cy:
       common_name: !!null 
       name: Kıbrıs
       official_name: !!null 
+      nationality: !!null 
     cz:
       common_name: !!null 
       name: Çek Cumhuriyeti
       official_name: !!null 
+      nationality: !!null 
     de:
       common_name: !!null 
       name: Almanya
       official_name: !!null 
+      nationality: !!null 
     dj:
       common_name: !!null 
       name: Cibuti
       official_name: !!null 
+      nationality: !!null 
     dk:
       common_name: !!null 
       name: Danimarka
       official_name: !!null 
+      nationality: !!null 
     dm:
       common_name: !!null 
       name: Dominika
       official_name: !!null 
+      nationality: !!null 
     do:
       common_name: !!null 
       name: Dominik Cumhuriyeti
       official_name: !!null 
+      nationality: !!null 
     dz:
       common_name: !!null 
       name: Cezayir
       official_name: !!null 
+      nationality: !!null 
     ec:
       common_name: !!null 
       name: Ekvator
       official_name: !!null 
+      nationality: !!null 
     ee:
       common_name: !!null 
       name: Estonya
       official_name: !!null 
+      nationality: !!null 
     eg:
       common_name: !!null 
       name: Mısır
       official_name: !!null 
+      nationality: !!null 
     eh:
       common_name: !!null 
       name: Batı Sahra
       official_name: !!null 
+      nationality: !!null 
     er:
       common_name: !!null 
       name: Eritre
       official_name: !!null 
+      nationality: !!null 
     es:
       common_name: !!null 
       name: İspanya
       official_name: !!null 
+      nationality: !!null 
     et:
       common_name: !!null 
       name: Etiyopya
       official_name: !!null 
+      nationality: !!null 
     fi:
       common_name: !!null 
       name: Finlandiya
       official_name: !!null 
+      nationality: !!null 
     fj:
       common_name: !!null 
       name: Fiji
       official_name: !!null 
+      nationality: !!null 
     fk:
       common_name: !!null 
       name: Falkland Adaları (Malvinas)
       official_name: !!null 
+      nationality: !!null 
     fm:
       common_name: !!null 
       name: Mikronezya Federal Devletleri
       official_name: !!null 
+      nationality: !!null 
     fo:
       common_name: !!null 
       name: Faroe Adaları
       official_name: !!null 
+      nationality: !!null 
     fr:
       common_name: !!null 
       name: Fransa
       official_name: !!null 
+      nationality: !!null 
     ga:
       common_name: !!null 
       name: Gabon
       official_name: !!null 
+      nationality: !!null 
     gb:
       common_name: !!null 
       name: Birleşik Krallık
       official_name: !!null 
+      nationality: !!null 
     gd:
       common_name: !!null 
       name: Grenada
       official_name: !!null 
+      nationality: !!null 
     ge:
       common_name: !!null 
       name: Gürcistan
       official_name: !!null 
+      nationality: !!null 
     gf:
       common_name: !!null 
       name: Fransız Guyanası
       official_name: !!null 
+      nationality: !!null 
     gh:
       common_name: !!null 
       name: Gana
       official_name: !!null 
+      nationality: !!null 
     gi:
       common_name: !!null 
       name: Gibraltar
       official_name: !!null 
+      nationality: !!null 
     gl:
       common_name: !!null 
       name: Grönland
       official_name: !!null 
+      nationality: !!null 
     gm:
       common_name: !!null 
       name: Gambiya
       official_name: !!null 
+      nationality: !!null 
     gn:
       common_name: !!null 
       name: Gine
       official_name: !!null 
+      nationality: !!null 
     gp:
       common_name: !!null 
       name: Guatelup
       official_name: !!null 
+      nationality: !!null 
     gq:
       common_name: !!null 
       name: Ekvator Ginesi
       official_name: !!null 
+      nationality: !!null 
     gr:
       common_name: !!null 
       name: Yunanistan
       official_name: !!null 
+      nationality: !!null 
     gt:
       common_name: !!null 
       name: Guatemala
       official_name: !!null 
+      nationality: !!null 
     gu:
       common_name: !!null 
       name: Guam
       official_name: !!null 
+      nationality: !!null 
     gw:
       common_name: !!null 
       name: Gine Bissau
       official_name: !!null 
+      nationality: !!null 
     gy:
       common_name: !!null 
       name: Guyena
       official_name: !!null 
+      nationality: !!null 
     hk:
       common_name: !!null 
       name: Hong Kong
       official_name: !!null 
+      nationality: !!null 
     hm:
       common_name: !!null 
       name: Heard Adası ve McDonald Adaları
       official_name: !!null 
+      nationality: !!null 
     hn:
       common_name: !!null 
       name: Honduras
       official_name: !!null 
+      nationality: !!null 
     hr:
       common_name: !!null 
       name: Hırvatistan
       official_name: !!null 
+      nationality: !!null 
     ht:
       common_name: !!null 
       name: Haiti
       official_name: !!null 
+      nationality: !!null 
     hu:
       common_name: !!null 
       name: Macaristan
       official_name: !!null 
+      nationality: !!null 
     id:
       common_name: !!null 
       name: Endonezya
       official_name: !!null 
+      nationality: !!null 
     ie:
       common_name: !!null 
       name: İrlanda
       official_name: !!null 
+      nationality: !!null 
     il:
       common_name: !!null 
       name: İsrail
       official_name: !!null 
+      nationality: !!null 
     in:
       common_name: !!null 
       name: Hindistan
       official_name: !!null 
+      nationality: !!null 
     io:
       common_name: !!null 
       name: İngiliz Hint Okyanus Bölgesi
       official_name: !!null 
+      nationality: !!null 
     iq:
       common_name: !!null 
       name: Irak
       official_name: !!null 
+      nationality: !!null 
     ir:
       common_name: !!null 
       name: İran
       official_name: !!null 
+      nationality: !!null 
     is:
       common_name: !!null 
       name: İzlanda
       official_name: !!null 
+      nationality: !!null 
     it:
       common_name: !!null 
       name: İtalya
       official_name: !!null 
+      nationality: !!null 
     jm:
       common_name: !!null 
       name: Jamaika
       official_name: !!null 
+      nationality: !!null 
     jo:
       common_name: !!null 
       name: Ürdün
       official_name: !!null 
+      nationality: !!null 
     jp:
       common_name: !!null 
       name: Japonya
       official_name: !!null 
+      nationality: !!null 
     ke:
       common_name: !!null 
       name: Kenya
       official_name: !!null 
+      nationality: !!null 
     kg:
       common_name: !!null 
       name: Kırgızistan
       official_name: !!null 
+      nationality: !!null 
     kh:
       common_name: !!null 
       name: Kamboçya
       official_name: !!null 
+      nationality: !!null 
     ki:
       common_name: !!null 
       name: Kiribati
       official_name: !!null 
+      nationality: !!null 
     km:
       common_name: !!null 
       name: Komor
       official_name: !!null 
+      nationality: !!null 
     kn:
       common_name: !!null 
       name: St. Kitts ve Nevis
       official_name: !!null 
+      nationality: !!null 
     kp:
       common_name: !!null 
       name: Kore, Kuzey
       official_name: !!null 
+      nationality: !!null 
     kr:
       common_name: !!null 
       name: Kore, Güney
       official_name: !!null 
+      nationality: !!null 
     kw:
       common_name: !!null 
       name: Kuveyt
       official_name: !!null 
+      nationality: !!null 
     ky:
       common_name: !!null 
       name: Cayman Adaları
       official_name: !!null 
+      nationality: !!null 
     kz:
       common_name: !!null 
       name: Kazakistan
       official_name: !!null 
+      nationality: !!null 
     la:
       common_name: !!null 
       name: Laos
       official_name: !!null 
+      nationality: !!null 
     lb:
       common_name: !!null 
       name: Lübnan
       official_name: !!null 
+      nationality: !!null 
     lc:
       common_name: !!null 
       name: Santa Lucia
       official_name: !!null 
+      nationality: !!null 
     li:
       common_name: !!null 
       name: Liechtenstein
       official_name: !!null 
+      nationality: !!null 
     lk:
       common_name: !!null 
       name: Sri Lanka
       official_name: !!null 
+      nationality: !!null 
     lr:
       common_name: !!null 
       name: Liberya
       official_name: !!null 
+      nationality: !!null 
     ls:
       common_name: !!null 
       name: Lesotho
       official_name: !!null 
+      nationality: !!null 
     lt:
       common_name: !!null 
       name: Litvanya
       official_name: !!null 
+      nationality: !!null 
     lu:
       common_name: !!null 
       name: Lüksemburg
       official_name: !!null 
+      nationality: !!null 
     lv:
       common_name: !!null 
       name: Letonya
       official_name: !!null 
+      nationality: !!null 
     ly:
       common_name: !!null 
       name: Libya
       official_name: !!null 
+      nationality: !!null 
     ma:
       common_name: !!null 
       name: Fas
       official_name: !!null 
+      nationality: !!null 
     mc:
       common_name: !!null 
       name: Monako
       official_name: !!null 
+      nationality: !!null 
     md:
       common_name: !!null 
       name: Moldova
       official_name: !!null 
+      nationality: !!null 
     me:
       common_name: !!null 
       name: Karadağ
       official_name: !!null 
+      nationality: !!null 
     mg:
       common_name: !!null 
       name: Madagaskar
       official_name: !!null 
+      nationality: !!null 
     mh:
       common_name: !!null 
       name: Marşal Adaları
       official_name: !!null 
+      nationality: !!null 
     mk:
       common_name: !!null 
       name: Makedonya
       official_name: !!null 
+      nationality: !!null 
     ml:
       common_name: !!null 
       name: Mali
       official_name: !!null 
+      nationality: !!null 
     mm:
       common_name: !!null 
       name: Myanmar
       official_name: !!null 
+      nationality: !!null 
     mn:
       common_name: !!null 
       name: Moğolistan
       official_name: !!null 
+      nationality: !!null 
     mo:
       common_name: !!null 
       name: Makao
       official_name: !!null 
+      nationality: !!null 
     mp:
       common_name: !!null 
       name: Kuzey Marian Adaları
       official_name: !!null 
+      nationality: !!null 
     mq:
       common_name: !!null 
       name: Martinik
       official_name: !!null 
+      nationality: !!null 
     mr:
       common_name: !!null 
       name: Moritanya
       official_name: !!null 
+      nationality: !!null 
     ms:
       common_name: !!null 
       name: Monserra
       official_name: !!null 
+      nationality: !!null 
     mt:
       common_name: !!null 
       name: Malta
       official_name: !!null 
+      nationality: !!null 
     mu:
       common_name: !!null 
       name: Mauritius
       official_name: !!null 
+      nationality: !!null 
     mv:
       common_name: !!null 
       name: Maldivler
       official_name: !!null 
+      nationality: !!null 
     mw:
       common_name: !!null 
       name: Malavi
       official_name: !!null 
+      nationality: !!null 
     mx:
       common_name: !!null 
       name: Meksika
       official_name: !!null 
+      nationality: !!null 
     my:
       common_name: !!null 
       name: Malezya
       official_name: !!null 
+      nationality: !!null 
     mz:
       common_name: !!null 
       name: Mozambik
       official_name: !!null 
+      nationality: !!null 
     na:
       common_name: !!null 
       name: Namibya
       official_name: !!null 
+      nationality: !!null 
     nc:
       common_name: !!null 
       name: Yeni Kaledonya
       official_name: !!null 
+      nationality: !!null 
     ne:
       common_name: !!null 
       name: Nijer
       official_name: !!null 
+      nationality: !!null 
     nf:
       common_name: !!null 
       name: Norfolk Adası
       official_name: !!null 
+      nationality: !!null 
     ng:
       common_name: !!null 
       name: Nijerya
       official_name: !!null 
+      nationality: !!null 
     ni:
       common_name: !!null 
       name: Nikaragua
       official_name: !!null 
+      nationality: !!null 
     nl:
       common_name: !!null 
       name: Hollanda
       official_name: !!null 
+      nationality: !!null 
     'no':
       common_name: !!null 
       name: Norveç
       official_name: !!null 
+      nationality: !!null 
     np:
       common_name: !!null 
       name: Nepal
       official_name: !!null 
+      nationality: !!null 
     nr:
       common_name: !!null 
       name: Nauru
       official_name: !!null 
+      nationality: !!null 
     nu:
       common_name: !!null 
       name: Niue
       official_name: !!null 
+      nationality: !!null 
     nz:
       common_name: !!null 
       name: Yeni Zelanda
       official_name: !!null 
+      nationality: !!null 
     om:
       common_name: !!null 
       name: Umman
       official_name: !!null 
+      nationality: !!null 
     pa:
       common_name: !!null 
       name: Panama
       official_name: !!null 
+      nationality: !!null 
     pe:
       common_name: !!null 
       name: Peru
       official_name: !!null 
+      nationality: !!null 
     pf:
       common_name: !!null 
       name: Fransız Polenezyası
       official_name: !!null 
+      nationality: !!null 
     pg:
       common_name: !!null 
       name: Papua Yeni Gine
       official_name: !!null 
+      nationality: !!null 
     ph:
       common_name: !!null 
       name: Filipinler
       official_name: !!null 
+      nationality: !!null 
     pk:
       common_name: !!null 
       name: Pakistan
       official_name: !!null 
+      nationality: !!null 
     pl:
       common_name: !!null 
       name: Polonya
       official_name: !!null 
+      nationality: !!null 
     pm:
       common_name: !!null 
       name: St. Pier ve Mikelon
       official_name: !!null 
+      nationality: !!null 
     pn:
       common_name: !!null 
       name: Pitkeirn
       official_name: !!null 
+      nationality: !!null 
     pr:
       common_name: !!null 
       name: Puerto Riko
       official_name: !!null 
+      nationality: !!null 
     pt:
       common_name: !!null 
       name: Portekiz
       official_name: !!null 
+      nationality: !!null 
     pw:
       common_name: !!null 
       name: Palau
       official_name: !!null 
+      nationality: !!null 
     py:
       common_name: !!null 
       name: Paraguay
       official_name: !!null 
+      nationality: !!null 
     qa:
       common_name: !!null 
       name: Katar
       official_name: !!null 
+      nationality: !!null 
     re:
       common_name: !!null 
       name: Reunyon
       official_name: !!null 
+      nationality: !!null 
     ro:
       common_name: !!null 
       name: Romanya
       official_name: !!null 
+      nationality: !!null 
     rs:
       common_name: !!null 
       name: Sırbistan
       official_name: !!null 
+      nationality: !!null 
     ru:
       common_name: !!null 
       name: Rusya
       official_name: !!null 
+      nationality: !!null 
     rw:
       common_name: !!null 
       name: Ruanda
       official_name: !!null 
+      nationality: !!null 
     sa:
       common_name: !!null 
       name: Suudi Arabistan
       official_name: !!null 
+      nationality: !!null 
     sb:
       common_name: !!null 
       name: Solomon Adaları
       official_name: !!null 
+      nationality: !!null 
     sc:
       common_name: !!null 
       name: Seyşeller
       official_name: !!null 
+      nationality: !!null 
     sd:
       common_name: !!null 
       name: Sudan
       official_name: !!null 
+      nationality: !!null 
     se:
       common_name: !!null 
       name: İsveç
       official_name: !!null 
+      nationality: !!null 
     sg:
       common_name: !!null 
       name: Singapur
       official_name: !!null 
+      nationality: !!null 
     sh:
       common_name: !!null 
       name: St. Helen
       official_name: !!null 
+      nationality: !!null 
     si:
       common_name: !!null 
       name: Slovenya
       official_name: !!null 
+      nationality: !!null 
     sj:
       common_name: !!null 
       name: Svalbard ve Jan Mayen
       official_name: !!null 
+      nationality: !!null 
     sk:
       common_name: !!null 
       name: Slovakya
       official_name: !!null 
+      nationality: !!null 
     sl:
       common_name: !!null 
       name: Sierra Leon
       official_name: !!null 
+      nationality: !!null 
     sm:
       common_name: !!null 
       name: San Marino
       official_name: !!null 
+      nationality: !!null 
     sn:
       common_name: !!null 
       name: Senegal
       official_name: !!null 
+      nationality: !!null 
     so:
       common_name: !!null 
       name: Somali
       official_name: !!null 
+      nationality: !!null 
     sr:
       common_name: !!null 
       name: Surinam
       official_name: !!null 
+      nationality: !!null 
     st:
       common_name: !!null 
       name: Sao Tome ve Prensip
       official_name: !!null 
+      nationality: !!null 
     sv:
       common_name: !!null 
       name: El Salvador
       official_name: !!null 
+      nationality: !!null 
     sy:
       common_name: !!null 
       name: Suriye
       official_name: !!null 
+      nationality: !!null 
     sz:
       common_name: !!null 
       name: Svaziland
       official_name: !!null 
+      nationality: !!null 
     tc:
       common_name: !!null 
       name: Türk ve Kaikos Adaları
       official_name: !!null 
+      nationality: !!null 
     td:
       common_name: !!null 
       name: Çad
       official_name: !!null 
+      nationality: !!null 
     tf:
       common_name: !!null 
       name: Fransa Güney Bölgesi
       official_name: !!null 
+      nationality: !!null 
     tg:
       common_name: !!null 
       name: Togo
       official_name: !!null 
+      nationality: !!null 
     th:
       common_name: !!null 
       name: Tayland
       official_name: !!null 
+      nationality: !!null 
     tj:
       common_name: !!null 
       name: Tacikistan
       official_name: !!null 
+      nationality: !!null 
     tk:
       common_name: !!null 
       name: Tokelau
       official_name: !!null 
+      nationality: !!null 
     tl:
       common_name: !!null 
       name: Timor-Leste
       official_name: !!null 
+      nationality: !!null 
     tm:
       common_name: !!null 
       name: Türkmenistan
       official_name: !!null 
+      nationality: !!null 
     tn:
       common_name: !!null 
       name: Tunus
       official_name: !!null 
+      nationality: !!null 
     to:
       common_name: !!null 
       name: Tonga
       official_name: !!null 
+      nationality: !!null 
     tr:
       common_name: !!null 
       name: Türkiye
       official_name: !!null 
+      nationality: !!null 
     tt:
       common_name: !!null 
       name: Trinidad ve Tobago
       official_name: !!null 
+      nationality: !!null 
     tv:
       common_name: !!null 
       name: Tuvalu
       official_name: !!null 
+      nationality: !!null 
     tw:
       common_name: !!null 
       name: Tayvan
       official_name: !!null 
+      nationality: !!null 
     tz:
       common_name: !!null 
       name: Tanzanya
       official_name: !!null 
+      nationality: !!null 
     ua:
       common_name: !!null 
       name: Ukrayna
       official_name: !!null 
+      nationality: !!null 
     ug:
       common_name: !!null 
       name: Uganda
       official_name: !!null 
+      nationality: !!null 
     um:
       common_name: !!null 
       name: A.B.D. Küçük Çevre Adaları
       official_name: !!null 
+      nationality: !!null 
     us:
       common_name: !!null 
       name: Amerika Birleşik Devletleri
       official_name: !!null 
+      nationality: !!null 
     uy:
       common_name: !!null 
       name: Uruguay
       official_name: !!null 
+      nationality: !!null 
     uz:
       common_name: !!null 
       name: Özbekistan
       official_name: !!null 
+      nationality: !!null 
     va:
       common_name: !!null 
       name: Vatikan
       official_name: !!null 
+      nationality: !!null 
     vc:
       common_name: !!null 
       name: St. Vensan ve Grenadines
       official_name: !!null 
+      nationality: !!null 
     ve:
       common_name: !!null 
       name: Venezuela
       official_name: !!null 
+      nationality: !!null 
     vg:
       common_name: !!null 
       name: Virjin Adaları, İngiltere
       official_name: !!null 
+      nationality: !!null 
     vi:
       common_name: !!null 
       name: Virjin Adaları, ABD
       official_name: !!null 
+      nationality: !!null 
     vn:
       common_name: !!null 
       name: Vietnam
       official_name: !!null 
+      nationality: !!null 
     vu:
       common_name: !!null 
       name: Vanuatu
       official_name: !!null 
+      nationality: !!null 
     wf:
       common_name: !!null 
       name: Valis ve Futuna
       official_name: !!null 
+      nationality: !!null 
     ws:
       common_name: !!null 
       name: Samoa
       official_name: !!null 
+      nationality: !!null 
     ye:
       common_name: !!null 
       name: Yemen
       official_name: !!null 
+      nationality: !!null 
     yt:
       common_name: !!null 
       name: Mayotte
       official_name: !!null 
+      nationality: !!null 
     za:
       common_name: !!null 
       name: Güney Afrika
       official_name: !!null 
+      nationality: !!null 
     zm:
       common_name: !!null 
       name: Zambiya
       official_name: !!null 
+      nationality: !!null 
     zw:
       common_name: !!null 
       name: Zimbabve
       official_name: !!null 
+      nationality: !!null 

--- a/spec/carmen/country_spec.rb
+++ b/spec/carmen/country_spec.rb
@@ -56,6 +56,10 @@ describe Carmen::Country do
     it 'has a reasonable inspect value' do
       @oceania.inspect.must_equal '<#Carmen::Country name="Oceania">'
     end
+    
+    it 'has a nationality method' do
+      @oceania.nationality.must_equal 'Oceanic'
+    end
   end
 
 

--- a/spec_data/locale/en/world.yml
+++ b/spec_data/locale/en/world.yml
@@ -1,15 +1,18 @@
---- 
+---
 en:
   world:
     oc:
       common_name: Oceania
       name: Oceania
       official_name: The Superstate of Oceania
+      nationality: Oceanic
     eu:
       common_name: Eurasia
       name: Eurasia
       official_name: The Superstate of Eurasia
+      nationality: !!null 
     es:
       common_name: Eastasia
       name: Eastasia
       official_name: The Superstate of Eastasia
+      nationality: !!null 


### PR DESCRIPTION
First of all, thank you for your hard work on compiling this list and make it ruby(autiful)!
I'm planning on use this gem on my next project because it's the only one I found who has proper locale handling.

As I'm gonna also need the nationality attribute for a given country (to acknowledge people's nationalities) I added them to the locales YAML files, so that it can be retrieved the very same way the rest of the country names are. Note though that I've only added nationality for the `en` locale.

I'd like to know your opinion on this and if you find it useful, I'll leave it as a pull request.

There are some minor issues I found (although I haven't read the ISO):
- There are some missing countries, at least from my knowledge. I.e.: Isn't England a country or is instead a region from Great Britain?
- There are some missing nationalities for the `en` locale
- None of the other locales have `nationality` filled
- I have some doubts against the name of the attribute. I'm not a native English speaker and I found 2 ways to say it: Nationality and Demonym.

Finally, I've created a TODO section on README so that is possible to track what's missing and what's planned to do.

Please give me some feedback when you can because I have some undergoing work that depends on both `carmen` and `carmen-rails` gems.

Keep up the good work!
