### PR TITLE
Case Insensitive Region Querying

### DIFF
--- a/lib/carmen/querying.rb
+++ b/lib/carmen/querying.rb
@@ -26,7 +26,7 @@ module Carmen
     # Returns a region with the supplied name, or nil if none if found.
     def named(name, options={})
       query_collection.find do |region|
-        name === region.name
+        name.downcase === region.name.downcase
       end
     end
 


### PR DESCRIPTION
A previous version of Carmen was case-insensitive when using .named, but it looks like that was lost in the refactor (unless I'm missing something?). With this one-line change, it's back!
