### PR TITLE
Remove double require of version

### DIFF
--- a/lib/carmen.rb
+++ b/lib/carmen.rb
@@ -6,7 +6,6 @@ $LOAD_PATH.unshift(lib_path)
 
 require 'carmen/country'
 require 'carmen/i18n'
-require 'carmen/version'
 
 module Carmen
   class << self


### PR DESCRIPTION
Hi Jim,

Carmen was throwing a already initialized constant VERSION warning here on 1.8.7, so I took out the second require of this file from lib/carmen. 

The gemspec also requires this file [1] and I think that's the correct place as the file itself is not being used in other places besides the gemspec.

[1] https://github.com/jim/carmen/blob/master/carmen.gemspec#L3
