### PR TITLE
Implement Unicode-safe case-folding for case-insensitive searching

### DIFF
--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', ["= 2.6.1"])
   s.add_development_dependency('nokogiri')
   s.add_development_dependency('rake', '0.9.2.2')
+  s.add_dependency('unicode_utils', '~> 1.4.0')
 end

--- a/lib/carmen/querying.rb
+++ b/lib/carmen/querying.rb
@@ -1,6 +1,7 @@
+require 'unicode_utils'
+
 module Carmen
   module Querying
-
     # Find a region by code.
     #
     # code - The String code to search for
@@ -11,8 +12,9 @@ module Carmen
       if attribute.nil?
         fail "could not find an attribute to search for code '#{code}'"
       end
+      code = code.downcase # Codes are all ASCII
       query_collection.find do |region|
-        region.send(attribute) == code
+        region.send(attribute).downcase == code
       end
     end
 
@@ -21,12 +23,21 @@ module Carmen
     # name - The String name to search for.
     # options - The Hash options used to modify the search (default:{}):
     #           :fuzzy - Whether to use fuzzy matching when finding a
-    #           matching name (optional, default: false)
+    #                    matching name (optional, default: false)
+    #           :case  - Whether or not the match is case-sensitive
+    #                    (optional, default: false)
     #
     # Returns a region with the supplied name, or nil if none if found.
     def named(name, options={})
+      case_fold = !options[:case] && name.respond_to?(:each_codepoint)
+      # These only need to be built once
+      name = case_fold ? UnicodeUtils.casefold(name) : name
+      # For now, "fuzzy" just means substring, optionally case-insensitive (the second argument looks for nil, not falseness)
+      regexp = options[:fuzzy] ? Regexp.new(name, options[:case] ? nil : true) : nil
+
       query_collection.find do |region|
-        name === region.name
+        found_literal = name === (case_fold && region.name ? UnicodeUtils.casefold(region.name) : region.name)
+        found_literal || options[:fuzzy] && regexp === region.name
       end
     end
 

--- a/spec/carmen/country_spec.rb
+++ b/spec/carmen/country_spec.rb
@@ -7,9 +7,32 @@ describe Carmen::Country do
     countries.size.must_equal 3
   end
 
-  it "provides an API for finding countries by name" do
-    eastasia = Carmen::Country.named('Eastasia')
-    eastasia.instance_of?(Carmen::Country).must_equal true
+  describe "API for finding countries by name" do
+    it "provides exact matching" do
+      eastasia = Carmen::Country.named('Eastasia')
+      eastasia.instance_of?(Carmen::Country).must_equal true
+    end
+
+    it "provides case-insensitive searches by default" do
+      eurasia = Carmen::Country.named('eUrAsIa')
+      eurasia.instance_of?(Carmen::Country).must_equal true
+      eurasia.name.must_equal 'Eurasia'
+    end
+
+    it "provides case-sensitive searches optionally" do
+      oceania = Carmen::Country.named('oCeAnIa', :case => true)
+      oceania.must_equal nil
+      oceania = Carmen::Country.named('Oceania', :case => true)
+      oceania.instance_of?(Carmen::Country).must_equal true
+      oceania.name.must_equal 'Oceania'
+    end
+
+    it "provides fuzzy (substring) matching optionally" do
+      eastasia = Carmen::Country.named('East', :fuzzy => true)
+      eastasia.instance_of?(Carmen::Country).must_equal true
+      eastasia.name.must_equal 'Eastasia'
+    end
+
   end
 
   it "provides an API for finding countries by code" do

--- a/spec/carmen/region_spec.rb
+++ b/spec/carmen/region_spec.rb
@@ -53,6 +53,26 @@ describe Carmen::Region do
       eastasia.name.must_equal('Eastasia')
     end
 
+    it "can find subregions by case-insensitive search by default" do
+      eurasia = @world.subregions.named('eUrAsIa')
+      eurasia.instance_of?(Carmen::Country).must_equal true
+      eurasia.name.must_equal 'Eurasia'
+    end
+
+    it "can find subregions optionally case-sensitively" do
+      oceania = @world.subregions.named('oCeAnIa', :case => true)
+      oceania.must_equal nil
+      oceania = @world.subregions.named('Oceania', :case => true)
+      oceania.instance_of?(Carmen::Country).must_equal true
+      oceania.name.must_equal 'Oceania'
+    end
+
+    it "can find subregions with fuzzy (substring) matching optionally" do
+      eastasia = @world.subregions.named('East', :fuzzy => true)
+      eastasia.instance_of?(Carmen::Country).must_equal true
+      eastasia.name.must_equal 'Eastasia'
+    end
+
     it 'can find subregions by name using a regex' do
       eastasia = @world.subregions.named(/Eastasia/)
       eastasia.name.must_equal('Eastasia')


### PR DESCRIPTION
As well as the :fuzzy option for Querying::named, which looks redundant to me since one is able to search via Regexp.
## 

Arguably :fuzzy should be a separate pull request, but I saw it in the comments and implemented it before I saw your response to my issue. 

Right now :fuzzy is a simple substring search. For a true “fuzzy” match, it should be something more like a Levenshtein distance weighted search. But I think you’re right that people just want it for type-ahead/autocomplete, and for that a substring is probably fine.

I can also take :fuzzy out and reimplement it as a separate method, if you’d prefer. Given that it’s off by default I don’t have a strong feeling about whether it should be its own method. Though I suppose the search method could be substring by default and fuzzy optionally, if someone wanted a Levenshtein distance algorithm (and felt like implementing it).
