### PR TITLE
Expose Country#numeric_code

### DIFF
--- a/lib/carmen/country.rb
+++ b/lib/carmen/country.rb
@@ -11,10 +11,12 @@ module Carmen
 
     attr_reader :alpha_2_code
     attr_reader :alpha_3_code
+    attr_reader :numeric_code
 
     def initialize(data={}, parent=nil)
       @alpha_2_code = data['alpha_2_code']
       @alpha_3_code = data['alpha_3_code']
+      @numeric_code = data['numeric_code']
       super
     end
 

--- a/spec/carmen/country_spec.rb
+++ b/spec/carmen/country_spec.rb
@@ -72,6 +72,10 @@ describe Carmen::Country do
       @oceania.code.must_equal 'OC'
     end
 
+    it "has a numeric code" do
+      @oceania.numeric_code.must_equal '001'
+    end
+
     it "has the world as a parent" do
       @oceania.parent.must_equal Carmen::World.instance
     end


### PR DESCRIPTION
Which was there in the YAML data, and mentioned in the README, but not
available on the API.
