### PR TITLE
Added AR-F 'La Rioja' 

### DIFF
--- a/iso_data/world/ar.yml
+++ b/iso_data/world/ar.yml
@@ -9,6 +9,8 @@
   type: province
 - code: E
   type: province
+- code: F
+  type: province
 - code: G
   type: province
 - code: H

--- a/locale/en/world/ar.yml
+++ b/locale/en/world/ar.yml
@@ -12,6 +12,8 @@ en:
         name: San Luis
       e:
         name: Entre Rios
+      f:
+        name: La Rioja
       g:
         name: Santiago del Estero
       h:


### PR DESCRIPTION
To be compliant with iso 3166 La Rioja should be included in the list
of Argentinian provinces. For reference:
https://www.iso.org/obp/ui/#iso:code:3166:AR
