### PR TITLE
Resolves subregion error when including additional data paths

### DIFF
--- a/lib/carmen/region.rb
+++ b/lib/carmen/region.rb
@@ -86,7 +86,11 @@ module Carmen
     # and overlaying matching data (if it exists) from the overlay_path.
     def load_data_at_path(path)
       data_sets = Carmen.data_paths.map do |data_path|
-        YAML.load_file(data_path + path)
+        if File.exists?(data_path + path)
+          YAML.load_file(data_path + path)
+        else
+          []
+        end
       end
       flatten_data(data_sets)
     end

--- a/spec/carmen/overlay_spec.rb
+++ b/spec/carmen/overlay_spec.rb
@@ -16,6 +16,18 @@ describe "Data overlaying" do
     sealand.type.must_equal('fort')
   end
 
+  it 'still finds elements that exist only in gem files' do
+    oceania = Carmen::Country.coded('OC')
+    oceania.instance_of?(Carmen::Country).must_equal true
+    oceania.type.must_equal('country')
+  end
+
+  it 'still finds subregions that exist only in gem files' do
+    oceania = Carmen::Country.coded('OC')
+    oceania.subregions?.must_equal true
+    oceania.subregions.named("Airstrip One").type.must_equal("province")
+  end
+
   it 'removes elements that have _enabled set to false' do
     Carmen::World.instance.subregions.size.must_equal(3)
     Carmen::Country.named('Eurasia').must_equal nil


### PR DESCRIPTION
This addresses an error with subregions when adding another `data_path` to Carmen. The library expected there to be subregion files in the added `data_path` for _all_ of the regions specified in the gem's included `world.yml` file, and thusly would throw an error when trying to load data from the non-existent YAML files, not allowing you to even access existing subregions.

I believe the specs are reasonable, but if you have any questions or suggestions just let me know. :)
