### PR TITLE
Fixes #131 by allowing nil code to be passed to querying.rb

### DIFF
--- a/lib/carmen/querying.rb
+++ b/lib/carmen/querying.rb
@@ -12,7 +12,7 @@ module Carmen
       if attribute.nil?
         fail "could not find an attribute to search for code '#{code}'"
       end
-      code = code.downcase # Codes are all ASCII
+      code = code.try(:downcase) # Codes are all ASCII
       query_collection.find do |region|
         region.send(attribute).downcase == code
       end


### PR DESCRIPTION
Multiple people, including myself were running into this error when following the carmen-rails how-to guide. After reviewing the code, I think handling a nil `code` in the querying.rb file is the best solution.
