### PR TITLE
Update naming for Brunei

### DIFF
--- a/locale/base/en/world.yml
+++ b/locale/base/en/world.yml
@@ -111,8 +111,8 @@ en:
       official_name: !!null 
     bn:
       common_name: !!null 
-      name: Brunei Darussalam
-      official_name: !!null 
+      name: Brunei
+      official_name: Nation of Brunei, the Abode of Peace
     bo:
       common_name: Bolivia
       name: Bolivia, Plurinational State of


### PR DESCRIPTION
Geography was never my strong side but I came across this problem when someone choose their country as "Brunei" from a country dropdown. Seems according to Wikipedia that the name is "Brunei" with the official name being "Nation of Brunei, Abode of Peace" while the official _Malay_ name is "Negara Brunei Darussalam".

Please correct me if I'm wrong though!
