### PR TITLE
Change Vietnam country name

### DIFF
--- a/locale/base/en/world.yml
+++ b/locale/base/en/world.yml
@@ -963,7 +963,7 @@ en:
       official_name: Virgin Islands of the United States
     vn:
       common_name: !!null 
-      name: Viet Nam
+      name: Vietnam
       official_name: Socialist Republic of Viet Nam
     vu:
       common_name: !!null 


### PR DESCRIPTION
Correct name of Vietnam http://en.wikipedia.org/wiki/Vietnam
