### PR TITLE
Load UnicodeUtils partially to speedup gem load time

### DIFF
--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', ["= 2.6.1"])
   s.add_development_dependency('nokogiri')
   s.add_development_dependency('rake', '0.9.2.2')
-  s.add_development_dependency('debugger')
+  s.add_development_dependency('byebug')
   s.add_dependency('unicode_utils', '~> 1.4.0')
 end

--- a/lib/carmen/querying.rb
+++ b/lib/carmen/querying.rb
@@ -1,4 +1,4 @@
-require 'unicode_utils'
+require 'unicode_utils/casefold'
 
 module Carmen
   module Querying

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require 'bundler/setup'
 require 'carmen'
 
-require 'debugger'
+require 'byebug'
 
 def setup_carmen_test_data_path
   Carmen.clear_data_paths


### PR DESCRIPTION
By requiring `unicode_utils/casefold` instead of `unicode_utils`, we gain around 350ms in gem load time without any loss in functionality.

Before:

```
>> puts Benchmark.measure { require 'carmen' }
  0.210000   0.140000   0.350000 (  0.352950)
```

After:

```
>> puts Benchmark.measure { require 'carmen' }
  0.020000   0.000000   0.020000 (  0.022928)
```

This also solves #141.
