### PR TITLE
Always return a RegionCollection from #subregions

### DIFF
--- a/lib/carmen/region.rb
+++ b/lib/carmen/region.rb
@@ -73,7 +73,7 @@ module Carmen
       if Carmen.data_paths.any? {|path| (path + subregion_data_path).exist? }
         load_subregions_from_path(subregion_data_path, self)
       else
-        []
+        RegionCollection.new([])
       end
     end
 


### PR DESCRIPTION
Prior to this, #load_subregions returned an empty array if there were no subregions. But there is no reason the calling code should have to check the return type before operating on the return value.