### PR TITLE
Add data for various regions of Yorkshire, GB

### DIFF
--- a/locale/base/en/world/gb.yml
+++ b/locale/base/en/world/gb.yml
@@ -296,6 +296,8 @@ en:
         name: North Lanarkshire
       nln:
         name: North Lincolnshire
+      nry:
+        name: North Riding of Yorkshire
       nsm:
         name: North Somerset
       nta:
@@ -416,6 +418,8 @@ en:
         name: Swindon
       swk:
         name: Southwark
+      syk:
+        name: South Yorkshire
       tam:
         name: Tameside
       tfw:
@@ -468,10 +472,16 @@ en:
         name: Warrington
       wrx:
         name: Wrexham;Wrecsam
+      wry:
+        name: West Riding of Yorkshire
       wsm:
         name: Westminster
       wsx:
         name: West Sussex
+      wyk:
+        name: West Yorkshire
+      yks:
+        name: Yorkshire
       yor:
         name: York
       zet:


### PR DESCRIPTION
Currently, there are some subdivisions missing so I added them for completeness (for example, North Yorkshire exists in regions but South Yorkshire is missing).

I retrieved all Yorkshire subdivisions and their chapman codes from  https://en.wikipedia.org/wiki/Chapman_code