### PR TITLE
Add subdivisions for Yorkshire, GB

### DIFF
--- a/iso_data/base/world/gb.yml
+++ b/iso_data/base/world/gb.yml
@@ -413,6 +413,8 @@
   type: unitary authority (england)
 - code: SWK
   type: london borough
+- code: SYK
+  type: metropolitan district
 - code: TAM
   type: metropolitan district
 - code: TFW
@@ -469,6 +471,8 @@
   type: london borough
 - code: WSX
   type: two-tier county
+- code: WYK
+  type: metropolitan district
 - code: YOR
   type: unitary authority (england)
 - code: ZET

--- a/locale/base/en/world/gb.yml
+++ b/locale/base/en/world/gb.yml
@@ -416,6 +416,8 @@ en:
         name: Swindon
       swk:
         name: Southwark
+      syk:
+        name: South Yorkshire
       tam:
         name: Tameside
       tfw:
@@ -472,6 +474,8 @@ en:
         name: Westminster
       wsx:
         name: West Sussex
+      wyk:
+        name: West Yorkshire
       yor:
         name: York
       zet:


### PR DESCRIPTION
For consistency reasons, I think all subdivisions of Yorkshire should be included. I have added South and West Yorkshire to complement the East and North divisions currently available.

