### PR TITLE
Delete overlay for SG as its numeric code should be 702

### DIFF
--- a/iso_data/overlay/world.yml
+++ b/iso_data/overlay/world.yml
@@ -1,5 +1,3 @@
 ---
 - alpha_2_code: PR
   _enabled: false
-- alpha_2_code: SG
-  numeric_code: '534'


### PR DESCRIPTION
This overlay incorrectly override iso data for SG here. The numeric code for SG should be 702 (https://en.wikipedia.org/wiki/ISO_3166-1).

I think this overlay was meant for [SX](https://github.com/jim/carmen/blob/master/iso_data/base/world.yml#L842-L844) instead of `SG`.

I checked the iso data for `SX` is already fixed, and thus this is not needed anymore.