### PR TITLE
Allow filtering subregions by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ similarly to a `Country` to find, for instance, a specific state:
     illinois = us.subregions.coded('IL')
     => <#Carmen::Region "Illinois">
 
+You can also find all subregions with a specific type:
+
+    states = us.subregions.typed('state')
+    => [<#Carmen::Region name="Alaska" type="state">, <#Carmen::Region name="Alabama" type="state">, ...]
+
 Subregions support a smaller set of attributes than countries:
 
     illinois.name

--- a/lib/carmen/region_collection.rb
+++ b/lib/carmen/region_collection.rb
@@ -16,6 +16,17 @@ module Carmen
   class RegionCollection < Array
     include Querying
 
+    # Filters the regions in this collection by type.
+    #
+    # type - The String type to filter by
+    #
+    # Returns a region collection containing all the regions with the supplied
+    # type.
+    def typed(type)
+      results = select{ |r| r.type.downcase == type.downcase }
+      Carmen::RegionCollection.new(results)
+    end
+
   private
 
     def query_collection

--- a/lib/carmen/region_collection.rb
+++ b/lib/carmen/region_collection.rb
@@ -23,7 +23,8 @@ module Carmen
     # Returns a region collection containing all the regions with the supplied
     # type.
     def typed(type)
-      results = select{ |r| r.type.downcase == type.downcase }
+      downcased_type = type.downcase
+      results = select{ |r| r.type == downcased_type }
       Carmen::RegionCollection.new(results)
     end
 

--- a/spec/carmen/region_collection_spec.rb
+++ b/spec/carmen/region_collection_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Carmen::RegionCollection do
+
+  before do
+    @collection = Carmen::RegionCollection.new([
+      Carmen::Region.new('type' => 'custom_type1', 'code' => 'AA'),
+      Carmen::Region.new('type' => 'custom_type2', 'code' => 'BB')
+    ])
+  end
+
+  it 'provides an API for filtering regions by type' do
+    @collection.typed('custom_type1').map(&:code).must_equal ['AA']
+  end
+
+end


### PR DESCRIPTION
This PR implements a `Carmen::RegionCollection#typed` method for finding all subregions with a specific type.