### PR TITLE
Fix Russia names

### DIFF
--- a/locale/base/en/world.yml
+++ b/locale/base/en/world.yml
@@ -763,8 +763,8 @@ en:
       official_name: Republic of Serbia
     ru:
       common_name: 
-      name: Russian Federation
-      official_name: 
+      name: Russia
+      official_name: Russian Federation
     rw:
       common_name: 
       name: Rwanda


### PR DESCRIPTION
Russia should be parsed either by `Russia` and `Russian Federation` names