### PR TITLE
Add serializers friendly to_hash. Fixes #209

### DIFF
--- a/lib/carmen/country.rb
+++ b/lib/carmen/country.rb
@@ -56,6 +56,10 @@ module Carmen
       alpha_2_code
     end
 
+    def to_hash
+      super.merge({ alpha_2_code: alpha_2_code, alpha_3_code: alpha_3_code, numeric_code: numeric_code })
+    end
+
   private
 
     def self.attribute_to_search_for_code(code)

--- a/lib/carmen/region.rb
+++ b/lib/carmen/region.rb
@@ -54,6 +54,10 @@ module Carmen
       name
     end
 
+    def to_hash
+      { type: type, code: code, name: name, subregions: subregions }
+    end
+
     # Clears the subregion cache
     def reset!
       @subregions = nil


### PR DESCRIPTION
Adds a generic method to_hash to Region and Country classes that can be used standalone or with Rails JSON Serializer.
Subregions can be excluded from the JSON by using standard notation `region.as_json(except: :subregions)`