### PR TITLE
Fix Bermuda subdivision names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   to sync with the ISO repository. Includes changes for BY, CN, GM, IN, KE, MA,  MK,
   MZ, NO, SS, and ZA ([@swcraig](https://github.com/swcraig)), [@JasonBarnabe](https://github.com/JasonBarnabe))
 * [#282](https://github.com/carmen-ruby/carmen/pull/282) 2020 Norway subregion updates ([@JasonBarnabe](https://github.com/JasonBarnabe))
+* [#290](https://github.com/carmen-ruby/carmen/pull/290) Correct names of subdivisions of Bermuda  ([@JasonBarnabe](https://github.com/JasonBarnabe))
 
 ### 1.1.2 (May 2, 2019)
 

--- a/locale/overlay/en/world/bm.yml
+++ b/locale/overlay/en/world/bm.yml
@@ -3,7 +3,7 @@ en:
   world:
     bm:
       dev:
-        name: Devenshire
+        name: Devonshire
       ham:
         name: Hamilton
       pag:
@@ -11,11 +11,11 @@ en:
       pem:
         name: Pembroke
       sge:
-        name: Saint George's
+        name: St. George's
       san:
         name: Sandys
       smi:
-        name: Smiths
+        name: Smith's
       sou:
         name: Southampton
       war:


### PR DESCRIPTION
- Devenshire -> Devonshire
- Saint George's -> St. George's
- Smiths -> Smith's

Per https://web.archive.org/web/20200715222940/https://www.gov.bm/sites/default/files/2016%20Census%20Report.pdf

The correct names for Devonshire and Smith's were referenced in the initial commit (#221) but were not present in the code. "St. George's" seems like a matter of style, but the government seems to refer to it as such.