### PR TITLE
Added new Chilean state Ñuble

### DIFF
--- a/iso_data/overlay/world/cl.yml
+++ b/iso_data/overlay/world/cl.yml
@@ -1,0 +1,2 @@
+- code: NB
+  type: region

--- a/locale/base/en/world/cl.yml
+++ b/locale/base/en/world/cl.yml
@@ -26,6 +26,8 @@ en:
         name: Magallanes y Antártica Chilena
       ml:
         name: Maule
+      nb:
+        name: Ñuble
       rm:
         name: Región Metropolitana de Santiago
       ta:


### PR DESCRIPTION
https://www.bcn.cl/siit/actualidad-territorial/nueva-region-de-nuble/actualidad-territorial/region-de-nuble/document_view2

Since September 6, 2018, the new region of Ñuble is constituted, formed by the twenty-one communes that made up the province of Ñuble, of the old Biobío Region, establishing the commune of Chillán as its regional capital.

* [x] I have read the [Wiki on how to make geographic changes](https://github.com/carmen-ruby/carmen/wiki/Contributing-Data) if this PR modifies geographic data
* [x] I have added a CHANGELOG entry if appropriate
